### PR TITLE
Date time axes

### DIFF
--- a/app/javascript/core/dateConversion.js
+++ b/app/javascript/core/dateConversion.js
@@ -41,7 +41,7 @@ wpd.dateConverter = (function () {
 	    var dateParts = dateString.split("/"),
 			year,
 			month,
-			day,
+			date,
 			tempDate,
 			rtnValue;
 

--- a/app/javascript/core/dateConversion.js
+++ b/app/javascript/core/dateConversion.js
@@ -38,7 +38,7 @@ wpd.dateConverter = (function () {
 
     function toJD(dateString) {
         dateString = dateString.toString();
-	    var dateParts = dateString.split(/[-/ :]/),
+	    var dateParts = dateString.split(/[/ :]/),
             hasDatePart = dateString.indexOf('/') >= 0,
 			year,
 			month,
@@ -191,7 +191,7 @@ wpd.dateConverter = (function () {
     }
 
     function getFormatString(dateString) {
-    	var dateParts = dateString.split(/[-/ :]/),
+    	var dateParts = dateString.split(/[/ :]/),
             hasDatePart = dateString.indexOf('/') >= 0,
             formatString = 'yyyy/mm/dd hh:ii:ss';
         

--- a/app/javascript/core/dateConversion.js
+++ b/app/javascript/core/dateConversion.js
@@ -180,12 +180,12 @@ wpd.dateConverter = (function () {
 
         outputString = outputString.replace("mmmm", longMonths[dateObject.getUTCMonth()]);
         outputString = outputString.replace("mmm", shortMonths[dateObject.getUTCMonth()]);
-        outputString = outputString.replace("mm", (dateObject.getUTCMonth()+1));
-        outputString = outputString.replace("dd", dateObject.getUTCDate());
+        outputString = outputString.replace("mm", ("0" + (dateObject.getUTCMonth()+1)).slice(-2));
+        outputString = outputString.replace("dd", ("0" + dateObject.getUTCDate()).slice(-2));
 
-        outputString = outputString.replace("hh", dateObject.getUTCHours());
-        outputString = outputString.replace("ii", dateObject.getUTCMinutes());
-        outputString = outputString.replace("ss", dateObject.getUTCSeconds());
+        outputString = outputString.replace("hh", ("0" + dateObject.getUTCHours()).slice(-2));
+        outputString = outputString.replace("ii", ("0" + dateObject.getUTCMinutes()).slice(-2));
+        outputString = outputString.replace("ss", ("0" + dateObject.getUTCSeconds()).slice(-2));
 				
 		return outputString;
     }

--- a/app/javascript/core/dateConversion.js
+++ b/app/javascript/core/dateConversion.js
@@ -193,9 +193,6 @@ wpd.dateConverter = (function () {
     function getFormatString(dateString) {
     	var dateParts = dateString.split(/[-/ :]/),
             hasDatePart = dateString.indexOf('/') >= 0,
-            year,
-            month,
-            date,
             formatString = 'yyyy/mm/dd hh:ii:ss';
         
         if(dateParts.length >= 1) {
@@ -228,7 +225,6 @@ wpd.dateConverter = (function () {
     return {
         parse: parse,
         getFormatString: getFormatString,
-        formatDate: formatDate,
         formatDateNumber: formatDateNumber
     };
 })();

--- a/app/javascript/core/dateConversion.js
+++ b/app/javascript/core/dateConversion.js
@@ -30,7 +30,7 @@ wpd.dateConverter = (function () {
         if(input == null) { return null; }
 
         if(typeof input === "string") {
-            if(input.indexOf('/') < 0) { return null; }
+            if(input.indexOf('/') < 0 && input.indexOf(':') < 0) { return null; }
         }
 
         return toJD(input);
@@ -38,24 +38,40 @@ wpd.dateConverter = (function () {
 
     function toJD(dateString) {
         dateString = dateString.toString();
-	    var dateParts = dateString.split("/"),
+	    var dateParts = dateString.split(/[-/ :]/),
+            hasDatePart = dateString.indexOf('/') >= 0,
 			year,
 			month,
 			date,
+            hour,
+            min,
+            sec,
+            timeIdxOffset,
+            today,
 			tempDate,
 			rtnValue;
 
-        if(dateParts.length <= 0 || dateParts.length > 3) {
+        if(dateParts.length <= 0 || dateParts.length > 6) {
             return null;
         }
 
-        year = parseInt(dateParts[0], 10);
+        if(hasDatePart){
+            year = parseInt(dateParts[0], 10);
+            month = parseInt(dateParts[1] === undefined ? 0 : dateParts[1], 10);
+            date = parseInt(dateParts[2] === undefined ? 1 : dateParts[2], 10);
+            timeIdxOffset = 3;
+        } else {
+            today = new Date();
+            year = today.getFullYear();
+            month = today.getMonth() + 1;
+            date = today.getDate();
+            timeIdxOffset = 0;
+        }
+        hour = parseInt(dateParts[timeIdxOffset] === undefined ? 0 : dateParts[timeIdxOffset], 10);
+        min = parseInt(dateParts[timeIdxOffset+1] === undefined ? 0 : dateParts[timeIdxOffset+1], 10);
+        sec = parseInt(dateParts[timeIdxOffset+2] === undefined ? 0 : dateParts[timeIdxOffset+2], 10);
 
-        month = parseInt(dateParts[1] === undefined ? 0 : dateParts[1], 10);
-
-        date = parseInt(dateParts[2] === undefined ? 1 : dateParts[2], 10);
-
-        if(isNaN(year) || isNaN(month) || isNaN(date)) {
+        if(isNaN(year) || isNaN(month) || isNaN(date) || isNaN(hour) || isNaN(min) || isNaN(sec)) {
             return null;
         }
 
@@ -67,11 +83,25 @@ wpd.dateConverter = (function () {
             return null;
         }
 
+        if(hour > 23 || hour < 0) {
+            return null;
+        }
+
+        if(min > 59 || min < 0) {
+            return null;
+        }
+
+        if(sec > 59 || sec < 0) {
+            return null;
+        }
+
+
         // Temporary till I figure out julian dates:
         tempDate = new Date();
         tempDate.setUTCFullYear(year);
         tempDate.setUTCMonth(month-1);
         tempDate.setUTCDate(date);
+        tempDate.setUTCHours(hour, min, sec);
         rtnValue = parseFloat(Date.parse(tempDate));
         if(!isNaN(rtnValue)) {
             return rtnValue;
@@ -79,18 +109,24 @@ wpd.dateConverter = (function () {
         return null;
     }
 
-    function fromJD(jd) {
-        // Temporary till I figure out julian dates:
-        jd = parseFloat(jd);
-        var msInDay = 24*60*60*1000,
-            roundedDate = parseInt(Math.round(jd/msInDay)*msInDay,10),
-            tempDate = new Date(roundedDate);
-
-        return tempDate;
-    }
-    
     function formatDateNumber(dateNumber, formatString) {
-        return formatDate(fromJD(dateNumber), formatString);
+        // round to smallest time unit
+        var coeff = 1;
+
+        if(formatString.indexOf('s') >= 0)
+            coeff = 1000;
+        else if(formatString.indexOf('i') >= 0)
+            coeff = 1000 * 60;
+        else if(formatString.indexOf('h') >= 0)
+            coeff = 1000 * 60 * 60;
+        else if(formatString.indexOf('d') >= 0)
+            coeff = 1000 * 60 * 60 * 24;
+        else if(formatString.indexOf('m') >= 0)
+            coeff = 1000 * 60 * 60 * 24 * 365.2425 / 12;
+        else if(formatString.indexOf('y') >= 0)
+            coeff = 1000 * 60 * 60 * 24 * 365.2425;
+
+        return formatDate(new Date(Math.round(new Date(dateNumber).getTime() / coeff) * coeff), formatString); 
     }
 
     function formatDate(dateObject, formatString) {
@@ -131,6 +167,9 @@ wpd.dateConverter = (function () {
         outputString = outputString.replace("MMM", "mmm");
         outputString = outputString.replace("MM", "mm");
         outputString = outputString.replace("DD", "dd");
+        outputString = outputString.replace("HH", "hh");
+        outputString = outputString.replace("II", "ii");
+        outputString = outputString.replace("SS", "ss");
 
         outputString = outputString.replace("yyyy", dateObject.getUTCFullYear());
 
@@ -143,27 +182,44 @@ wpd.dateConverter = (function () {
         outputString = outputString.replace("mmm", shortMonths[dateObject.getUTCMonth()]);
         outputString = outputString.replace("mm", (dateObject.getUTCMonth()+1));
         outputString = outputString.replace("dd", dateObject.getUTCDate());
+
+        outputString = outputString.replace("hh", dateObject.getUTCHours());
+        outputString = outputString.replace("ii", dateObject.getUTCMinutes());
+        outputString = outputString.replace("ss", dateObject.getUTCSeconds());
 				
 		return outputString;
     }
 
     function getFormatString(dateString) {
-    	var dateParts = dateString.split("/"),
+    	var dateParts = dateString.split(/[-/ :]/),
+            hasDatePart = dateString.indexOf('/') >= 0,
             year,
             month,
             date,
-            formatString = 'yyyy/mm/dd';
+            formatString = 'yyyy/mm/dd hh:ii:ss';
         
         if(dateParts.length >= 1) {
-            formatString = 'yyyy';
+            formatString = hasDatePart ? 'yyyy' : 'hh';
         }
 
         if(dateParts.length >= 2) {
-            formatString += '/mm';
+            formatString += hasDatePart ? '/mm' : ':ii';
         }
 
-        if(dateParts.length === 3) {
-            formatString += '/dd';
+        if(dateParts.length >= 3) {
+            formatString += hasDatePart ? '/dd' : ':ss';
+        }
+
+        if(dateParts.length >= 4) {
+            formatString += ' hh';
+        }
+
+        if(dateParts.length >= 5) {
+            formatString += ':ii';
+        }
+
+        if(dateParts.length === 6) {
+            formatString += ':ss';
         }
 
         return formatString;

--- a/app/templates/_popups.html
+++ b/app/templates/_popups.html
@@ -118,7 +118,7 @@
 	        <td align="center"><input type="checkbox" id="ylog" /></td>
 	    </tr>
 	</table>
-	<p align="center" class="footnote">{{ _("*For dates, use yyyy/mm/dd format (e.g. 2013/10/23 or 2013/10). For exponents, enter values as 1e-3 for 10^-3.") }}</p>
+	<p align="center" class="footnote">{{ _("*For dates, use yyyy/mm/dd hh:ii:ss format, where ii denotes minutes (e.g. 2013/10/23 or 2013/10 or 2013/10/23 10:15 or just 10:15). For exponents, enter values as 1e-3 for 10^-3.") }}</p>
 	<p>&nbsp;</p>
 	<p align="center"><input type="button" id="xybtn" value="{{ _("OK") }}" onclick="wpd.alignAxes.align();" /></p>
 	</center>


### PR DESCRIPTION
Enhance date axes and formatting to optionally include time info (in addtion to date part or on its own). See also #95.
The following rules apply:

- The placeholder for minutes is 'ii' as 'mm' is already used for months and the format string is not case sensitive.
- For both date and time parts, all bigger time units must be given starting from year or hour, respectively, down the to smallest unit needed (i.e. mm/dd or ii:ss are not valid, it must be yy/mm/dd or hh:ii:ss)
- When only the time part is used the date part is implicitely set to the current date.

 Correct rounding and add leading zeroes to one digit date and time numbers.