### PR TITLE
Data table NLS

### DIFF
--- a/app/javascript/core/dateConversion.js
+++ b/app/javascript/core/dateConversion.js
@@ -94,35 +94,17 @@ wpd.dateConverter = (function () {
     }
 
     function formatDate(dateObject, formatString) {
-        var longMonths = [
-                            "January", 
-                            "February", 
-                            "March", 
-                            "April", 
-                            "May", 
-                            "June", 
-                            "July", 
-                            "August", 
-                            "September",
-                            "October",
-                            "November",
-                            "December"
-                        ],
-            shortMonths = [
-                            "Jan",
-                            "Feb",
-                            "Mar",
-                            "Apr",
-                            "May",
-                            "Jun",
-                            "Jul",
-                            "Aug",
-                            "Sep",
-                            "Oct",
-                            "Nov",
-                            "Dec"
-                        ];
-        
+
+        var longMonths = [],
+            shortMonths = [],
+            tmpDate = new Date();
+
+        for(var i = 0; i < 12; i++) {
+            tmpDate.setUTCMonth(i);
+            longMonths.push(tmpDate.toLocaleString(undefined, {month:"long"}));
+            shortMonths.push(tmpDate.toLocaleString(undefined, {month:"short"}));
+        }
+
         var outputString = formatString;
 
         outputString = outputString.replace("YYYY", "yyyy");

--- a/app/javascript/widgets/dataTable.js
+++ b/app/javascript/widgets/dataTable.js
@@ -29,6 +29,7 @@ wpd.dataTable = (function () {
         dataCache,
         sortedData,
         tableText;
+    var decSeparator = 1.1.toLocaleString().replace(/\d/g,'');
     
     function showPlotData() {
         dataProvider = wpd.plotDataProvider;
@@ -51,7 +52,14 @@ wpd.dataTable = (function () {
     function show() {
         wpd.graphicsWidget.removeTool();
         wpd.popup.show('csvWindow');
+        initializeColSeparator();
         refresh();
+    }
+
+    function initializeColSeparator(){
+        // avoid colSeparator === decSeparator
+        if(document.getElementById('data-number-format-separator').value.trim() === decSeparator)
+            document.getElementById('data-number-format-separator').value = decSeparator === "," ? "; " : ", ";
     }
 
     function refresh() {
@@ -249,6 +257,7 @@ wpd.dataTable = (function () {
                             rowValues[coli] = sortedData[rowi][coli];
                         }
                     }
+                    rowValues[coli] = rowValues[coli].toString().replace('.', decSeparator);
                 }
             }
             tableText += rowValues.join(colSeparator);


### PR DESCRIPTION
Set decimal separator and month names to current (default) locale. Initialize column separator to be different from decimal separator. This greatly facilitates data transfer to non-English localized spreadsheet programs via clipboard.
(Surprisingly enough, localized separators do not confuse plot.ly)