### PR TITLE
Zoom calibration points when entering calibration values

### DIFF
--- a/app/javascript/tools/alignAxes.js
+++ b/app/javascript/tools/alignAxes.js
@@ -458,6 +458,11 @@ wpd.alignAxes = (function () {
         wpd.sidebar.show('axes-calibration-sidebar');
     }
 
+    function zoomCalPoint(i){
+        var calib = wpd.alignAxes.getActiveCalib(),
+            point = calib.getPoint(i);
+        wpd.graphicsWidget.updateZoomToImagePosn(point.px, point.py);
+    }
 
     function getCornerValues() {
         calibrator.getCornerValues();
@@ -508,6 +513,7 @@ wpd.alignAxes = (function () {
     return {
         start: initiatePlotAlignment,
         calibrationCompleted: calibrationCompleted,
+        zoomCalPoint: zoomCalPoint,
         getCornerValues: getCornerValues,
         align: align,
         getActiveCalib: getActiveCalib,

--- a/app/templates/_popups.html
+++ b/app/templates/_popups.html
@@ -107,14 +107,14 @@
 		</tr>
 	    <tr>
             <td align="center">{{ _("X-Axis") }}:</td>
-	        <td align="center"><input type="text" size="8" id="xmin" value="0" /></td>
-	        <td align="center"><input type="text" size="8" id="xmax" value="1" /></td>
+	        <td align="center"><input type="text" size="8" id="xmin" value="0" onfocus="wpd.alignAxes.zoomCalPoint(0);" /></td>
+	        <td align="center"><input type="text" size="8" id="xmax" value="1" onfocus="wpd.alignAxes.zoomCalPoint(1);" /></td>
 	        <td align="center"><input type="checkbox" id="xlog"></td>
 	    </tr>
 	    <tr>
             <td align="center">{{ _("Y-Axis") }}:</td>
-	        <td align="center"><input type="text" size="8" id="ymin" value="0" /></td>
-	        <td align="center"><input type="text" size="8" id="ymax" value="1" /></td>
+	        <td align="center"><input type="text" size="8" id="ymin" value="0" onfocus="wpd.alignAxes.zoomCalPoint(2);" /></td>
+	        <td align="center"><input type="text" size="8" id="ymax" value="1" onfocus="wpd.alignAxes.zoomCalPoint(3);" /></td>
 	        <td align="center"><input type="checkbox" id="ylog" /></td>
 	    </tr>
 	</table>
@@ -136,8 +136,8 @@
             <td align="center" valign="bottom" width="80">{{ _("Log Scale") }}</td>
         </tr>
         <tr>
-            <td align="center"><input type="text" size="8" id="bar-axes-p1" value="0" /></td>
-            <td align="center"><input type="text" size="8" id="bar-axes-p2" value="1" /></td>
+            <td align="center"><input type="text" size="8" id="bar-axes-p1" value="0" onfocus="wpd.alignAxes.zoomCalPoint(0);" /></td>
+            <td align="center"><input type="text" size="8" id="bar-axes-p2" value="1" onfocus="wpd.alignAxes.zoomCalPoint(1);"/></td>
             <td align="center"><input type="checkbox" id="bar-axes-log-scale"/></td>
         </tr>
     </table>
@@ -169,14 +169,14 @@
         </tr>
         <tr>
             <td>R: </td>
-            <td align="center"><input type="text" size="6" id="polar-r1" value="1"/></td>
-            <td align="center"><input type="text" size="6" id="polar-r2" value="1"/></td>
+            <td align="center"><input type="text" size="6" id="polar-r1" value="1" onfocus="wpd.alignAxes.zoomCalPoint(1);" /></td>
+            <td align="center"><input type="text" size="6" id="polar-r2" value="1" onfocus="wpd.alignAxes.zoomCalPoint(2);" /></td>
             <td align="center"><input type="checkbox" id="polar-log-scale"/></td>
         </tr>
         <tr>
             <td>Θ: </td>
-            <td align="center"><input type="text" size="6" id="polar-theta1" value="1"/></td>
-            <td align="center"><input type="text" size="6" id="polar-theta2" value="1"/></td>
+            <td align="center"><input type="text" size="6" id="polar-theta1" value="1" onfocus="wpd.alignAxes.zoomCalPoint(1);" /></td>
+            <td align="center"><input type="text" size="6" id="polar-theta2" value="1" onfocus="wpd.alignAxes.zoomCalPoint(2);" /></td>
             <td align="center">&nbsp;</td>
         </tr>
     </table>


### PR DESCRIPTION
When entering calibration values, show the current point in the zoom
window for better readability. This is especially helpful for large
images that are too small to be legible when fit to the window.