### PR TITLE
Show labels to the right of the points

### DIFF
--- a/app/javascript/core/calibration.js
+++ b/app/javascript/core/calibration.js
@@ -37,6 +37,7 @@ wpd.Calibration = (function () {
             selections = [];
 
         this.labels = [];
+        this.labelPositions = [];
 
         this.getCount = function () { return px.length; };
         this.getDimensions = function() { return dimensions; };

--- a/app/javascript/tools/alignAxes.js
+++ b/app/javascript/tools/alignAxes.js
@@ -30,13 +30,13 @@ wpd.xyCalibration = (function () {
     }
 
     function reload() {
-        var tool = new wpd.AxesCornersTool(4, 2, ['X1', 'X2', 'Y1', 'Y2'], true);
+        var tool = new wpd.AxesCornersTool(4, 2, ['X1', 'X2', 'Y1', 'Y2'], ['N', 'N', 'E', 'E'], true);
         wpd.graphicsWidget.setTool(tool);
     }
 
     function pickCorners() {
         wpd.popup.close('xyAxesInfo');
-        var tool = new wpd.AxesCornersTool(4, 2, ['X1', 'X2', 'Y1', 'Y2']);
+        var tool = new wpd.AxesCornersTool(4, 2, ['X1', 'X2', 'Y1', 'Y2'], ['N', 'N', 'E', 'E']);
         wpd.graphicsWidget.setTool(tool);
     }
 
@@ -94,13 +94,13 @@ wpd.barCalibration = (function () {
     }
 
     function reload() {
-        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2'], true);
+        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2'], ['S', 'S'], true);
         wpd.graphicsWidget.setTool(tool);
     }
 
     function pickCorners() {
         wpd.popup.close('barAxesInfo');
-        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2']);
+        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2'], ['S', 'S']);
         wpd.graphicsWidget.setTool(tool);
     }
 
@@ -148,13 +148,13 @@ wpd.polarCalibration = (function () {
     }
 
     function reload() {
-        var tool = new wpd.AxesCornersTool(3, 2, ['Origin', 'P1', 'P2'], true);
+        var tool = new wpd.AxesCornersTool(3, 2, ['Origin', 'P1', 'P2'], ['E', 'S', 'S'], true);
         wpd.graphicsWidget.setTool(tool);
     }
 
     function pickCorners() {
         wpd.popup.close('polarAxesInfo');
-        var tool = new wpd.AxesCornersTool(3, 2, ['Origin', 'P1', 'P2']);
+        var tool = new wpd.AxesCornersTool(3, 2, ['Origin', 'P1', 'P2'], ['E', 'S', 'S']);
         wpd.graphicsWidget.setTool(tool);
     }
 
@@ -204,13 +204,13 @@ wpd.ternaryCalibration = (function () {
     }
 
     function reload() {
-        var tool = new wpd.AxesCornersTool(3, 3, ['A', 'B', 'C'], true);
+        var tool = new wpd.AxesCornersTool(3, 3, ['A', 'B', 'C'], ['S', 'S', 'E'], true);
         wpd.graphicsWidget.setTool(tool);
     }
 
     function pickCorners() {
         wpd.popup.close('ternaryAxesInfo');
-        var tool = new wpd.AxesCornersTool(3, 3, ['A', 'B', 'C']);
+        var tool = new wpd.AxesCornersTool(3, 3, ['A', 'B', 'C'], ['S', 'S', 'E']);
         wpd.graphicsWidget.setTool(tool);
     }
 
@@ -251,13 +251,13 @@ wpd.mapCalibration = (function () {
     }
 
     function reload() {
-        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2'],true);
+        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2'], ['S', 'S'], true);
         wpd.graphicsWidget.setTool(tool);
     }
 
     function pickCorners() {
         wpd.popup.close('mapAxesInfo');
-        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2']);
+        var tool = new wpd.AxesCornersTool(2, 2, ['P1', 'P2'], ['S', 'S']);
         wpd.graphicsWidget.setTool(tool);
     }
 
@@ -293,7 +293,7 @@ wpd.mapCalibration = (function () {
 
 wpd.AxesCornersTool = (function () {
 
-    var Tool = function(maxPoints, dimensions, pointLabels, reloadTool) {
+    var Tool = function(maxPoints, dimensions, pointLabels, pointLabelPositions, reloadTool) {
         var pointCount = 0,
             ncal = new wpd.Calibration(dimensions),
             isCapturingCorners = true; 
@@ -307,6 +307,7 @@ wpd.AxesCornersTool = (function () {
             ncal = new wpd.Calibration(dimensions);
             isCapturingCorners = true;
             ncal.labels = pointLabels;
+            ncal.labelPositions = pointLabelPositions;
             wpd.alignAxes.setActiveCalib(ncal);
             wpd.graphicsWidget.resetData();
         }
@@ -402,7 +403,7 @@ wpd.AlignmentCornersRepainter = (function () {
         		    fillStyle = "rgba(200,0,0,1)";
                 }
 
-                wpd.graphicsHelper.drawPoint(imagePx, fillStyle, cal.labels[i]);
+                wpd.graphicsHelper.drawPoint(imagePx, fillStyle, cal.labels[i], cal.labelPositions[i]);
             }
         };
     };

--- a/app/javascript/tools/graphicsHelper.js
+++ b/app/javascript/tools/graphicsHelper.js
@@ -39,9 +39,9 @@ wpd.graphicsHelper = (function () {
             ctx.dataCtx.font = "15px sans-serif";
             labelWidth = ctx.dataCtx.measureText(label).width;
             ctx.dataCtx.fillStyle = "rgba(255, 255, 255, 0.7)";
-            ctx.dataCtx.fillRect(screenPx.x - 13, screenPx.y - 8, labelWidth + 5, 35);
+            ctx.dataCtx.fillRect(screenPx.x - 7, screenPx.y - 16, labelWidth + 17, 26);
             ctx.dataCtx.fillStyle = fillStyle;
-            ctx.dataCtx.fillText(label, screenPx.x - 10, screenPx.y + 18);
+            ctx.dataCtx.fillText(label, screenPx.x + 7, screenPx.y + 5);
         }
 
         ctx.dataCtx.beginPath();
@@ -56,7 +56,7 @@ wpd.graphicsHelper = (function () {
             // No translucent background for text here.
             ctx.oriDataCtx.font = "15px sans-serif";
             ctx.oriDataCtx.fillStyle = fillStyle;
-            ctx.oriDataCtx.fillText(label, imagePx.x - 10, imagePx.y + 18);
+            ctx.oriDataCtx.fillText(label, imagePx.x + 7, imagePx.y + 5);
         }
 
         ctx.oriDataCtx.beginPath();

--- a/app/javascript/tools/graphicsHelper.js
+++ b/app/javascript/tools/graphicsHelper.js
@@ -28,22 +28,56 @@ wpd.graphicsHelper = (function () {
     // imagePx - relative to original image
     // fillStyle - e.g. "rgb(200,0,0)"
     // label - e.g. "Bar 0"
-    function drawPoint(imagePx, fillStyle, label) {
+    // position - "N", "E", "S" (default), or "W"
+    function drawPoint(imagePx, fillStyle, label, position) {
         var screenPx = wpd.graphicsWidget.screenPx(imagePx.x, imagePx.y),
             ctx = wpd.graphicsWidget.getAllContexts(),
             labelWidth,
             imageHeight = wpd.graphicsWidget.getImageSize().height;
 
-        // Display Data Canvas Layer
         if(label != null) {
+            // Display Data Canvas Layer
             ctx.dataCtx.font = "15px sans-serif";
             labelWidth = ctx.dataCtx.measureText(label).width;
             ctx.dataCtx.fillStyle = "rgba(255, 255, 255, 0.7)";
-            ctx.dataCtx.fillRect(screenPx.x - 7, screenPx.y - 16, labelWidth + 17, 26);
-            ctx.dataCtx.fillStyle = fillStyle;
-            ctx.dataCtx.fillText(label, screenPx.x + 7, screenPx.y + 5);
+
+            // Original Image Data Canvas Layer
+            // No translucent background for text here.
+            ctx.oriDataCtx.font = "15px sans-serif";
+            ctx.oriDataCtx.fillStyle = fillStyle;
+
+            // Switch for both canvases
+            switch(position){
+                case "N":
+                case "n":
+                    ctx.dataCtx.fillRect(screenPx.x - 13, screenPx.y - 24, labelWidth + 5, 35);
+                    ctx.dataCtx.fillStyle = fillStyle;
+                    ctx.dataCtx.fillText(label, screenPx.x - 10, screenPx.y - 7);
+                    ctx.oriDataCtx.fillText(label, imagePx.x - 10, imagePx.y - 7);
+                    break;
+                case "E":
+                case "e":
+                    ctx.dataCtx.fillRect(screenPx.x - 7, screenPx.y - 16, labelWidth + 17, 26);
+                    ctx.dataCtx.fillStyle = fillStyle;
+                    ctx.dataCtx.fillText(label, screenPx.x + 7, screenPx.y + 5);
+                    ctx.oriDataCtx.fillText(label, imagePx.x + 7, imagePx.y + 5);
+                    break;
+                case "W":
+                case "w":
+                    ctx.dataCtx.fillRect(screenPx.x - labelWidth - 10, screenPx.y - 16, labelWidth + 17, 26);
+                    ctx.dataCtx.fillStyle = fillStyle;
+                    ctx.dataCtx.fillText(label, screenPx.x - labelWidth - 7, screenPx.y + 5);
+                    ctx.oriDataCtx.fillText(label, imagePx.x - labelWidth - 7, imagePx.y + 5);
+                    break;
+                default:
+                    ctx.dataCtx.fillRect(screenPx.x - 13, screenPx.y - 8, labelWidth + 5, 35);
+                    ctx.dataCtx.fillStyle = fillStyle;
+                    ctx.dataCtx.fillText(label, screenPx.x - 10, screenPx.y + 18);
+                    ctx.oriDataCtx.fillText(label, imagePx.x - 10, imagePx.y + 18);
+            }
         }
 
+        // Display Data Canvas Layer
         ctx.dataCtx.beginPath();
         ctx.dataCtx.fillStyle = fillStyle;
         ctx.dataCtx.strokeStyle = "rgb(255, 255, 255)";
@@ -52,13 +86,6 @@ wpd.graphicsHelper = (function () {
         ctx.dataCtx.stroke();
 
         // Original Image Data Canvas Layer
-        if(label != null) {
-            // No translucent background for text here.
-            ctx.oriDataCtx.font = "15px sans-serif";
-            ctx.oriDataCtx.fillStyle = fillStyle;
-            ctx.oriDataCtx.fillText(label, imagePx.x + 7, imagePx.y + 5);
-        }
-
         ctx.oriDataCtx.beginPath();
         ctx.oriDataCtx.fillStyle = fillStyle;
         ctx.oriDataCtx.strokeStyle = "rgb(255, 255, 255)";


### PR DESCRIPTION
Labels below the points overlap with tick labels in the image when
calibrating the horizontal (x) axis, which makes it difficult to
read the tick labels during calibration. The position to the right
of the point seems most suitable for the majority of cases.
![labels](https://user-images.githubusercontent.com/19879328/30867368-0b167466-a2dc-11e7-8a32-f6163b791fb2.PNG)

This is the easiest and most straightforward solution for me to improve useability right now. A more sophisticated approach could check the share of background color pixels (=most dominant color) for all four positions (below, above, to the right, to the left) and the pick the one with the highest background share. Maybe I'll try something like that when I have some more time.