### PR TITLE
Copy datatable to clipboard

### DIFF
--- a/app/javascript/widgets/dataTable.js
+++ b/app/javascript/widgets/dataTable.js
@@ -274,7 +274,11 @@ wpd.dataTable = (function () {
 
     function copyToClipboard() {
         selectAll();
-        document.execCommand('copy');
+        try {
+            document.execCommand('copy');
+        } catch(ex) {
+            console.log('copyToClipboard', ex.message);
+        }
     }
 
     function generateCSV() {

--- a/app/javascript/widgets/dataTable.js
+++ b/app/javascript/widgets/dataTable.js
@@ -266,19 +266,17 @@ wpd.dataTable = (function () {
         $digitizedDataTable.value = tableText;
     }
 
-    function selectAll() {
+
+    function copyToClipboard() {
         var $digitizedDataTable = document.getElementById('digitizedDataTable');
         $digitizedDataTable.focus();
         $digitizedDataTable.select();
-    }
-
-    function copyToClipboard() {
-        selectAll();
         try {
             document.execCommand('copy');
         } catch(ex) {
             console.log('copyToClipboard', ex.message);
         }
+        $digitizedDataTable.blur();
     }
 
     function generateCSV() {
@@ -327,7 +325,6 @@ wpd.dataTable = (function () {
         showDistanceData: showDistanceData,
         updateSortingControls: updateSortingControls,
         reSort: reSort,
-        selectAll: selectAll,
         copyToClipboard: copyToClipboard,
         generateCSV: generateCSV,
         exportToPlotly: exportToPlotly,

--- a/app/javascript/widgets/dataTable.js
+++ b/app/javascript/widgets/dataTable.js
@@ -272,6 +272,11 @@ wpd.dataTable = (function () {
         $digitizedDataTable.select();
     }
 
+    function copyToClipboard() {
+        selectAll();
+        document.execCommand('copy');
+    }
+
     function generateCSV() {
         var datasetName = dataProvider.getDatasetNames()[dataProvider.getDatasetIndex()];
         wpd.download.csv(tableText, datasetName + ".csv");
@@ -319,6 +324,7 @@ wpd.dataTable = (function () {
         updateSortingControls: updateSortingControls,
         reSort: reSort,
         selectAll: selectAll,
+        copyToClipboard: copyToClipboard,
         generateCSV: generateCSV,
         exportToPlotly: exportToPlotly,
         changeDataset: changeDataset

--- a/app/locale/messages.pot
+++ b/app/locale/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-09-23 20:30-0500\n"
+"POT-Creation-Date: 2017-09-27 20:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.5.1\n"
 
 #: templates/_base.html:26
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -308,7 +308,7 @@ msgid "Variables"
 msgstr ""
 
 #: templates/_popups.html:220
-msgid "Select All"
+msgid "Copy to Clipboard"
 msgstr ""
 
 #: templates/_popups.html:221 templates/_popups.html:440

--- a/app/templates/_popups.html
+++ b/app/templates/_popups.html
@@ -217,7 +217,6 @@
     <p align="center">{{ _("Variables") }}: <span id="dataVariables"></span></p>
 	<p align="center"><textarea id="digitizedDataTable" style="width: 480px; height: 250px;"></textarea></p>
 	<p align="center">
-		<input type="button" value="{{ _("Select All") }}" onclick="wpd.dataTable.selectAll();"/>
           	<input type="button" value="{{ _("Copy to Clipboard") }}" onclick="wpd.dataTable.copyToClipboard();"/>
         <input type="button" value="{{ _("Download .CSV") }}" onclick="wpd.dataTable.generateCSV();"/>
 		<input type="button" value="{{ _("Graph in Plotly*") }}" onclick="wpd.dataTable.exportToPlotly();"/>

--- a/app/templates/_popups.html
+++ b/app/templates/_popups.html
@@ -218,6 +218,7 @@
 	<p align="center"><textarea id="digitizedDataTable" style="width: 480px; height: 250px;"></textarea></p>
 	<p align="center">
 		<input type="button" value="{{ _("Select All") }}" onclick="wpd.dataTable.selectAll();"/>
+          	<input type="button" value="{{ _("Copy to Clipboard") }}" onclick="wpd.dataTable.copyToClipboard();"/>
         <input type="button" value="{{ _("Download .CSV") }}" onclick="wpd.dataTable.generateCSV();"/>
 		<input type="button" value="{{ _("Graph in Plotly*") }}" onclick="wpd.dataTable.exportToPlotly();"/>
 		<input type="button" value="{{ _("Close") }}" onclick="wpd.popup.close('csvWindow');"/>


### PR DESCRIPTION
Same as 'Select all' but additionally copies the selection to the
clipboard. This seems to make 'Select all' unnecessary but I'd
leave it as fallback for some old browsers where the copying may
not work.