### PR TITLE
Fix minor typos and documentation update

### DIFF
--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -34,7 +34,7 @@ Web Server:
 
 Electron App:
 - `electron-packager` npm package to create packages for distributions
-- `wine` on Linux systems to create Windows distributins
+- `wine` on Linux systems to create Windows distributions
 - Run `npm install` in the electron folder to fetch any other dependencies
 
 ## Building Source

--- a/docs/JSON_format_specification.md
+++ b/docs/JSON_format_specification.md
@@ -24,6 +24,7 @@ Version specifies the major and minor version of the file format as a JSON numbe
 "axesColl" is an array of objects defining each axis in the file.  Generally, each axis in the file is defined by the following names and values:
 
 * "name" is the string name for the axis as provided by the user.
+* "page" is the integer page number within the file.
 * "type" is the string type of axis (further details are below).
 * "calibrationPoints" are the points used to calibrate the axis.
     * "px" and "py" are the x and y points for calibration in pixel units as a number.
@@ -85,6 +86,7 @@ When "type" is "ImageAxes", only "name" and "type" are defined and no calibratio
 The dataset objects are made of the following name/value pairs:
 
 * "name" is the string name for the axis as provided by the user.
+* "page" is the integer page number within the file.
 * "axesName" is the name of the axes associated with the dataset.  It must be a name given in the "name" field for one of the axes defined in "axesColl".
 * "metadataKeys" is an empty array or it gives information on the use of the "metadata" in each data point object.
 * "data" are a vector of data point objects in the dataset.

--- a/webserver/main.go
+++ b/webserver/main.go
@@ -30,7 +30,7 @@ func main() {
 	// read server settings
 	settings, err := ReadServerSettings("settings.json")
 	if err != nil {
-		log.Fatal("Error reading setting.json")
+		log.Fatal("Error reading settings.json")
 	}
 
 	// host the ui frontend


### PR DESCRIPTION
For the first commit: This error message typo briefly confused me.
The second commit was another minor typo.
The third commit was an update to address file format updates for page numbering.