### PR TITLE
fix quit confirmation message box

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -36,17 +36,22 @@ function createWindow () {
     mainWindow = null
   })
 
-  mainWindow.on('close', function(e) {
-      var choice = electron.dialog.showMessageBox(this,
-        {
-          type: 'question',
-          buttons: ['Yes', 'No'],
-          title: 'Confirm',
-          message: 'Are you sure you want to quit?'
-       });
-       if(choice == 1){
-         e.preventDefault();
-       }
+  var allow_quit = false;
+  mainWindow.on('close', async function(e) {
+    if(!allow_quit) {
+      e.preventDefault();
+      var choice = await electron.dialog.showMessageBox(mainWindow,
+          {
+              type: 'question',
+              buttons: ['Yes', 'No'],
+              title: 'Confirm',
+              message: 'Are you sure you want to quit?'
+          });
+      if(choice.response == 0){
+        allow_quit = true;
+        app.quit();
+      }
+    }
   })
 
   // Add Edit menu for Mac to allow copy-paste:


### PR DESCRIPTION
At least on Linux, the exit confirmation isn't working because `electron.dialog.showMessageBox` is async and returns a promise. I get the beep as the message box starts to be created, but then the app quits before it appears.

I tried simply `await`ing the message box but it had no effect. It seems you have to call `preventDefault` as fast as possible to keep the app open. This fix applies the hack shown [here](https://stackoverflow.com/a/63813373/1114328).