### PR TITLE
Update thirdparty

### DIFF
--- a/app/thirdparty/getThirdparty.sh
+++ b/app/thirdparty/getThirdparty.sh
@@ -3,13 +3,13 @@
 # closure compiler
 mkdir -p closure-compiler
 cd closure-compiler
-wget https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v20200719/closure-compiler-v20200719.jar
+wget https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/v20210406/closure-compiler-v20210406.jar
 jarfile=(*.jar)
 ln -s $jarfile compiler.jar
 cd ..
 
 # PDFJS
-wget -O pdfjs.zip https://github.com/mozilla/pdf.js/releases/download/v2.1.266/pdfjs-2.1.266-dist.zip
+wget -O pdfjs.zip https://github.com/mozilla/pdf.js/releases/download/v2.7.570/pdfjs-2.7.570-dist.zip
 unzip pdfjs.zip -d pdfjs
 
 # tarballjs

--- a/research/Dockerfile
+++ b/research/Dockerfile
@@ -5,7 +5,7 @@
 # docker run -p 8080:8080 webplotdigitizer:dev
 
 # Set the base image to a long-term Ubuntu release
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Dockerfile Maintainer
 MAINTAINER William Denney <wdenney@humanpredictions.com>
@@ -20,9 +20,12 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive \
        dpkg-reconfigure --frontend noninteractive tzdata
 
+ARG GITREPO=https://github.com/ankitrohatgi/WebPlotDigitizer.git
+ARG GITBRANCH=master
 
-RUN git clone https://github.com/ankitrohatgi/WebPlotDigitizer.git \
+RUN git clone $GITREPO \
     && cd WebPlotDigitizer \
+    && git checkout $GITBRANCH \
     && grep -v wine setupUbuntuDev.sh | \
        sed 's/apt install/apt-get install --yes --no-install-recommends/' > setupUbuntuDev-aptfix.sh \
     && chmod +x setupUbuntuDev-aptfix.sh \

--- a/setupUbuntuDev.sh
+++ b/setupUbuntuDev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Setup an Ubuntu 18.04 system for development
+# Setup an Ubuntu 20.04 system for development
 
 # install Ubuntu packages
 sudo apt install \
@@ -9,7 +9,7 @@ sudo apt install \
      wine-stable \
      npm \
      default-jre \
-     golang-go \
+     golang \
      libeigen3-dev
 
 # install global npm packages


### PR DESCRIPTION
This updates to the current pdf.js and current closure-compiler.  It is on top of #255 since it seemed in the same vein of updating to more current versions of everything (so, I'm about to close that one).

I tested to confirm that I could load the web page and that I could open a .pdf file.  I believe that if a .pdf is viewable and I can switch pages, pdf.js is fully tested, but if some more testing is needed, please let me know how to test that.