### PR TITLE
Fixed issue deserializing axis metadata

### DIFF
--- a/app/javascript/core/plotData.js
+++ b/app/javascript/core/plotData.js
@@ -394,8 +394,8 @@ wpd.PlotData = class {
                 if (axes != null) {
                     axes.name = axData.name;
 
-                    if (axes.metadata !== undefined) {
-                        axes.metadata = axData.metadata;
+                    if (axData.metadata !== undefined) {
+                        axes.setMetadata(axData.metadata);
                     }
 
                     this._axesColl.push(axes);


### PR DESCRIPTION
Hi Ankit, hope you're doing well. Got a small bug fix here.

I noticed axis metadata was not loading correctly from saved JSON files. Dataset metadata and pixel metadata were loading fine. Turns out, the conditional and assignment statements were both incorrect.

I will be adding unit tests for the serialize and deserialize functions in the near future.