### PR TITLE
Added popup to delete associated datasets on axes delete

### DIFF
--- a/app/javascript/controllers/axesCalibration.js
+++ b/app/javascript/controllers/axesCalibration.js
@@ -537,35 +537,42 @@ wpd.alignAxes = (function() {
             });
         };
 
-        wpd.okCancelPopup.show(
-            wpd.gettext("delete-associated-datasets"),
-            wpd.gettext("delete-associated-datasets-text"),
-            () => {
-                const plotData = wpd.appData.getPlotData();
-                const axes = wpd.tree.getActiveAxes();
+        const plotData = wpd.appData.getPlotData();
+        const axes = wpd.tree.getActiveAxes();
 
-                // get all datasets and filter to datasets of active axes
-                const datasets = plotData.getDatasets();
-                const axesDatasets = datasets.filter((ds) => plotData.getAxesForDataset(ds) === axes);
+        // get all datasets and filter to datasets of active axes
+        const datasets = plotData.getDatasets();
+        const axesDatasets = datasets.filter((ds) => plotData.getAxesForDataset(ds) === axes);
 
-                for (const dataset of axesDatasets) {
-                    plotData.deleteDataset(dataset);
-                    wpd.appData.getFileManager().deleteDatasetsFromCurrentFile([dataset]);
-                    if (wpd.appData.isMultipage()) {
-                        wpd.appData.getPageManager().deleteDatasetsFromCurrentPage([dataset]);
+        if (axesDatasets.length > 0) {
+            // only display delete associated datasets popup if they exist
+            wpd.okCancelPopup.show(
+                wpd.gettext("delete-associated-datasets"),
+                wpd.gettext("delete-associated-datasets-text"),
+                () => {
+                    for (const dataset of axesDatasets) {
+                        plotData.deleteDataset(dataset);
+                        wpd.appData.getFileManager().deleteDatasetsFromCurrentFile([dataset]);
+                        if (wpd.appData.isMultipage()) {
+                            wpd.appData.getPageManager().deleteDatasetsFromCurrentPage([dataset]);
+                        }
+                        // dispatch dataset delete event
+                        wpd.events.dispatch("wpd.dataset.delete", {
+                            dataset: dataset
+                        });
+
+                        // no need to refresh the tree here
                     }
-                    // dispatch dataset delete event
-                    wpd.events.dispatch("wpd.dataset.delete", {
-                        dataset: dataset
-                    });
 
-                    // no need to refresh the tree here
-                }
-
-                deleteAxes();
-            },
-            deleteAxes,
-        );
+                    deleteAxes();
+                },
+                deleteAxes,
+            );
+        }
+        else {
+            // otherwise, proceed to delete the axes
+            deleteAxes();
+        }
     }
 
     function showRenameAxes() {

--- a/app/locale/de_DE/LC_MESSAGES/messages.po
+++ b/app/locale/de_DE/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-01 23:57-0800\n"
+"POT-Creation-Date: 2022-03-29 11:21-0400\n"
 "PO-Revision-Date: 2019-02-24 00:40-0800\n"
 "Last-Translator: \n"
 "Language: de_DE\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: templates/_base.html:27
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -112,7 +112,7 @@ msgstr ""
 #: templates/_popups.html:571 templates/_popups.html:583
 #: templates/_popups.html:594 templates/_popups.html:604
 #: templates/_popups.html:615 templates/_popups.html:647
-#: templates/_popups.html:697 templates/_strings.html:74
+#: templates/_popups.html:697 templates/_strings.html:76
 msgid "Cancel"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgstr ""
 #: templates/_popups.html:218 templates/_popups.html:256
 #: templates/_popups.html:283 templates/_popups.html:528
 #: templates/_popups.html:541 templates/_popups.html:555
-#: templates/_popups.html:627 templates/_strings.html:73
+#: templates/_popups.html:627 templates/_strings.html:75
 msgid "OK"
 msgstr ""
 
@@ -203,8 +203,8 @@ msgstr ""
 msgid "Map With Scale Bar"
 msgstr ""
 
-#: templates/_popups.html:112 templates/_strings.html:56
-#: templates/_strings.html:70 templates/_tree.html:8
+#: templates/_popups.html:112 templates/_strings.html:58
+#: templates/_strings.html:72 templates/_tree.html:8
 msgid "Image"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Acquired Data"
 msgstr ""
 
-#: templates/_popups.html:294 templates/_strings.html:48
+#: templates/_popups.html:294 templates/_strings.html:50
 #: templates/_tree.html:51
 msgid "Dataset"
 msgstr ""
@@ -776,11 +776,11 @@ msgid ""
 "-1. The process would repeat for the next set of points."
 msgstr ""
 
-#: templates/_popups.html:682 templates/_strings.html:81
+#: templates/_popups.html:682 templates/_strings.html:83
 msgid "Group"
 msgstr ""
 
-#: templates/_popups.html:685 templates/_strings.html:83
+#: templates/_popups.html:685 templates/_strings.html:85
 msgid "Primary Group"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Click to change color"
 msgstr ""
 
-#: templates/_sidebars.html:33 templates/_strings.html:52
+#: templates/_sidebars.html:33 templates/_strings.html:54
 #: templates/_tree.html:44 templates/_tree.html:65
 msgid "Distance"
 msgstr ""
@@ -1152,191 +1152,199 @@ msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
 #: templates/_strings.html:29
-msgid "Delete Axes"
+msgid "Delete Associated Datasets"
 msgstr ""
 
 #: templates/_strings.html:30
-msgid "Are you sure you want to delete this axes?"
+msgid "Delete all datasets associated with this axes?"
 msgstr ""
 
 #: templates/_strings.html:31
-msgid "Averaging Window"
+msgid "Delete Axes"
 msgstr ""
 
 #: templates/_strings.html:32
-msgid "X Step w/ Interpolation"
+msgid "Are you sure you want to delete this axes?"
 msgstr ""
 
 #: templates/_strings.html:33
-msgid "Custom Independents"
+msgid "Averaging Window"
 msgstr ""
 
 #: templates/_strings.html:34
-msgid "X Step"
+msgid "X Step w/ Interpolation"
 msgstr ""
 
 #: templates/_strings.html:35
-msgid "Blob Detector"
+msgid "Custom Independents"
 msgstr ""
 
 #: templates/_strings.html:36
-msgid "Bar Extraction"
+msgid "X Step"
 msgstr ""
 
 #: templates/_strings.html:37
-msgid "Histogram"
+msgid "Blob Detector"
 msgstr ""
 
 #: templates/_strings.html:38
-msgid "Specify Plot (Foreground) Color"
+msgid "Bar Extraction"
 msgstr ""
 
 #: templates/_strings.html:39
-msgid "Specify Background Color"
+msgid "Histogram"
 msgstr ""
 
 #: templates/_strings.html:40
-msgid "Please add some data before exporting."
+msgid "Specify Plot (Foreground) Color"
 msgstr ""
 
 #: templates/_strings.html:41
-msgid "Error: No datasets to export!"
+msgid "Specify Background Color"
 msgstr ""
 
 #: templates/_strings.html:42
-msgid "Add Dataset Error!"
+msgid "Please add some data before exporting."
 msgstr ""
 
 #: templates/_strings.html:43
-msgid "Rename Dataset Error!"
+msgid "Error: No datasets to export!"
 msgstr ""
 
 #: templates/_strings.html:44
-msgid "Dataset with this name already exists. Please pick a different name."
+msgid "Add Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:45
-msgid "Rename Axes Error!"
+msgid "Rename Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:46
-msgid "Axes with this name already exists. Please pick a different name."
+msgid "Dataset with this name already exists. Please pick a different name."
 msgstr ""
 
 #: templates/_strings.html:47
+msgid "Rename Axes Error!"
+msgstr ""
+
+#: templates/_strings.html:48
+msgid "Axes with this name already exists. Please pick a different name."
+msgstr ""
+
+#: templates/_strings.html:49
 msgid "Specify a valid number of datasets to add!"
 msgstr ""
 
-#: templates/_strings.html:49 templates/_tree.html:34
+#: templates/_strings.html:51 templates/_tree.html:34
 msgid "Datasets"
 msgstr ""
 
-#: templates/_strings.html:50 templates/_tree.html:42
+#: templates/_strings.html:52 templates/_tree.html:42
 msgid "Measurements"
 msgstr ""
 
-#: templates/_strings.html:51 templates/_tree.html:15 templates/_tree.html:25
+#: templates/_strings.html:53 templates/_tree.html:15 templates/_tree.html:25
 #: templates/_tree.html:53 templates/_tree.html:67 templates/_tree.html:84
 msgid "Axes"
 msgstr ""
 
-#: templates/_strings.html:53 templates/_tree.html:45 templates/_tree.html:74
+#: templates/_strings.html:55 templates/_tree.html:45 templates/_tree.html:74
 msgid "Angle"
 msgstr ""
 
-#: templates/_strings.html:54 templates/_tree.html:46 templates/_tree.html:82
+#: templates/_strings.html:56 templates/_tree.html:46 templates/_tree.html:82
 msgid "Area/Perimeter"
 msgstr ""
 
-#: templates/_strings.html:55
+#: templates/_strings.html:57
 msgid "XY"
 msgstr ""
 
-#: templates/_strings.html:57
+#: templates/_strings.html:59
 msgid "Bar"
 msgstr ""
 
-#: templates/_strings.html:58
+#: templates/_strings.html:60
 msgid "Polar"
 msgstr ""
 
-#: templates/_strings.html:59
+#: templates/_strings.html:61
 msgid "Ternary"
 msgstr ""
 
-#: templates/_strings.html:60
+#: templates/_strings.html:62
 msgid "Map"
 msgstr ""
 
-#: templates/_strings.html:61
+#: templates/_strings.html:63
 msgid "Circular Chart"
 msgstr ""
 
-#: templates/_strings.html:62
+#: templates/_strings.html:64
 msgid "Project"
 msgstr ""
 
-#: templates/_strings.html:63
+#: templates/_strings.html:65
 msgid "Distance Measurements"
 msgstr ""
 
-#: templates/_strings.html:64
+#: templates/_strings.html:66
 msgid "Angle Measurements"
 msgstr ""
 
-#: templates/_strings.html:65
+#: templates/_strings.html:67
 msgid "Area Measurements"
 msgstr ""
 
-#: templates/_strings.html:66
+#: templates/_strings.html:68
 msgid "Uncalibrated Dataset!"
 msgstr ""
 
-#: templates/_strings.html:67
+#: templates/_strings.html:69
 msgid "Assign an axes calibration to this dataset!"
 msgstr ""
 
-#: templates/_strings.html:68
+#: templates/_strings.html:70
 msgid "Invalid Project!"
 msgstr ""
 
-#: templates/_strings.html:69
+#: templates/_strings.html:71
 msgid "Not a valid project file format!"
 msgstr ""
 
-#: templates/_strings.html:71
+#: templates/_strings.html:73
 msgid "of"
 msgstr ""
 
-#: templates/_strings.html:72
+#: templates/_strings.html:74
 msgid "Page"
 msgstr ""
 
-#: templates/_strings.html:75
+#: templates/_strings.html:77
 msgid "Yes"
 msgstr ""
 
-#: templates/_strings.html:76
+#: templates/_strings.html:78
 msgid "No"
 msgstr ""
 
-#: templates/_strings.html:77
+#: templates/_strings.html:79
 msgid "Delete Point Tuple"
 msgstr ""
 
-#: templates/_strings.html:78
+#: templates/_strings.html:80
 msgid "Delete all points in the tuple?"
 msgstr ""
 
-#: templates/_strings.html:79 templates/_strings.html:82
+#: templates/_strings.html:81 templates/_strings.html:84
 msgid "Delete Group"
 msgstr ""
 
-#: templates/_strings.html:80
+#: templates/_strings.html:82
 msgid "Delete all points in deleted groups?"
 msgstr ""
 
-#: templates/_strings.html:84
+#: templates/_strings.html:86
 msgid "new tuple"
 msgstr ""
 

--- a/app/locale/en_US/LC_MESSAGES/messages.po
+++ b/app/locale/en_US/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-01 23:57-0800\n"
+"POT-Creation-Date: 2022-03-29 11:21-0400\n"
 "PO-Revision-Date: 2016-12-12 23:09-0600\n"
 "Last-Translator: \n"
 "Language: en_US\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: templates/_base.html:27
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -112,7 +112,7 @@ msgstr ""
 #: templates/_popups.html:571 templates/_popups.html:583
 #: templates/_popups.html:594 templates/_popups.html:604
 #: templates/_popups.html:615 templates/_popups.html:647
-#: templates/_popups.html:697 templates/_strings.html:74
+#: templates/_popups.html:697 templates/_strings.html:76
 msgid "Cancel"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgstr ""
 #: templates/_popups.html:218 templates/_popups.html:256
 #: templates/_popups.html:283 templates/_popups.html:528
 #: templates/_popups.html:541 templates/_popups.html:555
-#: templates/_popups.html:627 templates/_strings.html:73
+#: templates/_popups.html:627 templates/_strings.html:75
 msgid "OK"
 msgstr ""
 
@@ -203,8 +203,8 @@ msgstr ""
 msgid "Map With Scale Bar"
 msgstr ""
 
-#: templates/_popups.html:112 templates/_strings.html:56
-#: templates/_strings.html:70 templates/_tree.html:8
+#: templates/_popups.html:112 templates/_strings.html:58
+#: templates/_strings.html:72 templates/_tree.html:8
 msgid "Image"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Acquired Data"
 msgstr ""
 
-#: templates/_popups.html:294 templates/_strings.html:48
+#: templates/_popups.html:294 templates/_strings.html:50
 #: templates/_tree.html:51
 msgid "Dataset"
 msgstr ""
@@ -776,11 +776,11 @@ msgid ""
 "-1. The process would repeat for the next set of points."
 msgstr ""
 
-#: templates/_popups.html:682 templates/_strings.html:81
+#: templates/_popups.html:682 templates/_strings.html:83
 msgid "Group"
 msgstr ""
 
-#: templates/_popups.html:685 templates/_strings.html:83
+#: templates/_popups.html:685 templates/_strings.html:85
 msgid "Primary Group"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Click to change color"
 msgstr ""
 
-#: templates/_sidebars.html:33 templates/_strings.html:52
+#: templates/_sidebars.html:33 templates/_strings.html:54
 #: templates/_tree.html:44 templates/_tree.html:65
 msgid "Distance"
 msgstr ""
@@ -1152,191 +1152,199 @@ msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
 #: templates/_strings.html:29
-msgid "Delete Axes"
+msgid "Delete Associated Datasets"
 msgstr ""
 
 #: templates/_strings.html:30
-msgid "Are you sure you want to delete this axes?"
+msgid "Delete all datasets associated with this axes?"
 msgstr ""
 
 #: templates/_strings.html:31
-msgid "Averaging Window"
+msgid "Delete Axes"
 msgstr ""
 
 #: templates/_strings.html:32
-msgid "X Step w/ Interpolation"
+msgid "Are you sure you want to delete this axes?"
 msgstr ""
 
 #: templates/_strings.html:33
-msgid "Custom Independents"
+msgid "Averaging Window"
 msgstr ""
 
 #: templates/_strings.html:34
-msgid "X Step"
+msgid "X Step w/ Interpolation"
 msgstr ""
 
 #: templates/_strings.html:35
-msgid "Blob Detector"
+msgid "Custom Independents"
 msgstr ""
 
 #: templates/_strings.html:36
-msgid "Bar Extraction"
+msgid "X Step"
 msgstr ""
 
 #: templates/_strings.html:37
-msgid "Histogram"
+msgid "Blob Detector"
 msgstr ""
 
 #: templates/_strings.html:38
-msgid "Specify Plot (Foreground) Color"
+msgid "Bar Extraction"
 msgstr ""
 
 #: templates/_strings.html:39
-msgid "Specify Background Color"
+msgid "Histogram"
 msgstr ""
 
 #: templates/_strings.html:40
-msgid "Please add some data before exporting."
+msgid "Specify Plot (Foreground) Color"
 msgstr ""
 
 #: templates/_strings.html:41
-msgid "Error: No datasets to export!"
+msgid "Specify Background Color"
 msgstr ""
 
 #: templates/_strings.html:42
-msgid "Add Dataset Error!"
+msgid "Please add some data before exporting."
 msgstr ""
 
 #: templates/_strings.html:43
-msgid "Rename Dataset Error!"
+msgid "Error: No datasets to export!"
 msgstr ""
 
 #: templates/_strings.html:44
-msgid "Dataset with this name already exists. Please pick a different name."
+msgid "Add Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:45
-msgid "Rename Axes Error!"
+msgid "Rename Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:46
-msgid "Axes with this name already exists. Please pick a different name."
+msgid "Dataset with this name already exists. Please pick a different name."
 msgstr ""
 
 #: templates/_strings.html:47
+msgid "Rename Axes Error!"
+msgstr ""
+
+#: templates/_strings.html:48
+msgid "Axes with this name already exists. Please pick a different name."
+msgstr ""
+
+#: templates/_strings.html:49
 msgid "Specify a valid number of datasets to add!"
 msgstr ""
 
-#: templates/_strings.html:49 templates/_tree.html:34
+#: templates/_strings.html:51 templates/_tree.html:34
 msgid "Datasets"
 msgstr ""
 
-#: templates/_strings.html:50 templates/_tree.html:42
+#: templates/_strings.html:52 templates/_tree.html:42
 msgid "Measurements"
 msgstr ""
 
-#: templates/_strings.html:51 templates/_tree.html:15 templates/_tree.html:25
+#: templates/_strings.html:53 templates/_tree.html:15 templates/_tree.html:25
 #: templates/_tree.html:53 templates/_tree.html:67 templates/_tree.html:84
 msgid "Axes"
 msgstr ""
 
-#: templates/_strings.html:53 templates/_tree.html:45 templates/_tree.html:74
+#: templates/_strings.html:55 templates/_tree.html:45 templates/_tree.html:74
 msgid "Angle"
 msgstr ""
 
-#: templates/_strings.html:54 templates/_tree.html:46 templates/_tree.html:82
+#: templates/_strings.html:56 templates/_tree.html:46 templates/_tree.html:82
 msgid "Area/Perimeter"
 msgstr ""
 
-#: templates/_strings.html:55
+#: templates/_strings.html:57
 msgid "XY"
 msgstr ""
 
-#: templates/_strings.html:57
+#: templates/_strings.html:59
 msgid "Bar"
 msgstr ""
 
-#: templates/_strings.html:58
+#: templates/_strings.html:60
 msgid "Polar"
 msgstr ""
 
-#: templates/_strings.html:59
+#: templates/_strings.html:61
 msgid "Ternary"
 msgstr ""
 
-#: templates/_strings.html:60
+#: templates/_strings.html:62
 msgid "Map"
 msgstr ""
 
-#: templates/_strings.html:61
+#: templates/_strings.html:63
 msgid "Circular Chart"
 msgstr ""
 
-#: templates/_strings.html:62
+#: templates/_strings.html:64
 msgid "Project"
 msgstr ""
 
-#: templates/_strings.html:63
+#: templates/_strings.html:65
 msgid "Distance Measurements"
 msgstr ""
 
-#: templates/_strings.html:64
+#: templates/_strings.html:66
 msgid "Angle Measurements"
 msgstr ""
 
-#: templates/_strings.html:65
+#: templates/_strings.html:67
 msgid "Area Measurements"
 msgstr ""
 
-#: templates/_strings.html:66
+#: templates/_strings.html:68
 msgid "Uncalibrated Dataset!"
 msgstr ""
 
-#: templates/_strings.html:67
+#: templates/_strings.html:69
 msgid "Assign an axes calibration to this dataset!"
 msgstr ""
 
-#: templates/_strings.html:68
+#: templates/_strings.html:70
 msgid "Invalid Project!"
 msgstr ""
 
-#: templates/_strings.html:69
+#: templates/_strings.html:71
 msgid "Not a valid project file format!"
 msgstr ""
 
-#: templates/_strings.html:71
+#: templates/_strings.html:73
 msgid "of"
 msgstr ""
 
-#: templates/_strings.html:72
+#: templates/_strings.html:74
 msgid "Page"
 msgstr ""
 
-#: templates/_strings.html:75
+#: templates/_strings.html:77
 msgid "Yes"
 msgstr ""
 
-#: templates/_strings.html:76
+#: templates/_strings.html:78
 msgid "No"
 msgstr ""
 
-#: templates/_strings.html:77
+#: templates/_strings.html:79
 msgid "Delete Point Tuple"
 msgstr ""
 
-#: templates/_strings.html:78
+#: templates/_strings.html:80
 msgid "Delete all points in the tuple?"
 msgstr ""
 
-#: templates/_strings.html:79 templates/_strings.html:82
+#: templates/_strings.html:81 templates/_strings.html:84
 msgid "Delete Group"
 msgstr ""
 
-#: templates/_strings.html:80
+#: templates/_strings.html:82
 msgid "Delete all points in deleted groups?"
 msgstr ""
 
-#: templates/_strings.html:84
+#: templates/_strings.html:86
 msgid "new tuple"
 msgstr ""
 

--- a/app/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/app/locale/fr_FR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-01 23:57-0800\n"
+"POT-Creation-Date: 2022-03-29 11:21-0400\n"
 "PO-Revision-Date: 2017-11-01 23:56-0500\n"
 "Last-Translator: \n"
 "Language: fr_FR\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: templates/_base.html:27
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -112,7 +112,7 @@ msgstr ""
 #: templates/_popups.html:571 templates/_popups.html:583
 #: templates/_popups.html:594 templates/_popups.html:604
 #: templates/_popups.html:615 templates/_popups.html:647
-#: templates/_popups.html:697 templates/_strings.html:74
+#: templates/_popups.html:697 templates/_strings.html:76
 msgid "Cancel"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgstr ""
 #: templates/_popups.html:218 templates/_popups.html:256
 #: templates/_popups.html:283 templates/_popups.html:528
 #: templates/_popups.html:541 templates/_popups.html:555
-#: templates/_popups.html:627 templates/_strings.html:73
+#: templates/_popups.html:627 templates/_strings.html:75
 msgid "OK"
 msgstr ""
 
@@ -203,8 +203,8 @@ msgstr ""
 msgid "Map With Scale Bar"
 msgstr ""
 
-#: templates/_popups.html:112 templates/_strings.html:56
-#: templates/_strings.html:70 templates/_tree.html:8
+#: templates/_popups.html:112 templates/_strings.html:58
+#: templates/_strings.html:72 templates/_tree.html:8
 msgid "Image"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Acquired Data"
 msgstr ""
 
-#: templates/_popups.html:294 templates/_strings.html:48
+#: templates/_popups.html:294 templates/_strings.html:50
 #: templates/_tree.html:51
 msgid "Dataset"
 msgstr ""
@@ -776,11 +776,11 @@ msgid ""
 "-1. The process would repeat for the next set of points."
 msgstr ""
 
-#: templates/_popups.html:682 templates/_strings.html:81
+#: templates/_popups.html:682 templates/_strings.html:83
 msgid "Group"
 msgstr ""
 
-#: templates/_popups.html:685 templates/_strings.html:83
+#: templates/_popups.html:685 templates/_strings.html:85
 msgid "Primary Group"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Click to change color"
 msgstr ""
 
-#: templates/_sidebars.html:33 templates/_strings.html:52
+#: templates/_sidebars.html:33 templates/_strings.html:54
 #: templates/_tree.html:44 templates/_tree.html:65
 msgid "Distance"
 msgstr ""
@@ -1152,191 +1152,199 @@ msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
 #: templates/_strings.html:29
-msgid "Delete Axes"
+msgid "Delete Associated Datasets"
 msgstr ""
 
 #: templates/_strings.html:30
-msgid "Are you sure you want to delete this axes?"
+msgid "Delete all datasets associated with this axes?"
 msgstr ""
 
 #: templates/_strings.html:31
-msgid "Averaging Window"
+msgid "Delete Axes"
 msgstr ""
 
 #: templates/_strings.html:32
-msgid "X Step w/ Interpolation"
+msgid "Are you sure you want to delete this axes?"
 msgstr ""
 
 #: templates/_strings.html:33
-msgid "Custom Independents"
+msgid "Averaging Window"
 msgstr ""
 
 #: templates/_strings.html:34
-msgid "X Step"
+msgid "X Step w/ Interpolation"
 msgstr ""
 
 #: templates/_strings.html:35
-msgid "Blob Detector"
+msgid "Custom Independents"
 msgstr ""
 
 #: templates/_strings.html:36
-msgid "Bar Extraction"
+msgid "X Step"
 msgstr ""
 
 #: templates/_strings.html:37
-msgid "Histogram"
+msgid "Blob Detector"
 msgstr ""
 
 #: templates/_strings.html:38
-msgid "Specify Plot (Foreground) Color"
+msgid "Bar Extraction"
 msgstr ""
 
 #: templates/_strings.html:39
-msgid "Specify Background Color"
+msgid "Histogram"
 msgstr ""
 
 #: templates/_strings.html:40
-msgid "Please add some data before exporting."
+msgid "Specify Plot (Foreground) Color"
 msgstr ""
 
 #: templates/_strings.html:41
-msgid "Error: No datasets to export!"
+msgid "Specify Background Color"
 msgstr ""
 
 #: templates/_strings.html:42
-msgid "Add Dataset Error!"
+msgid "Please add some data before exporting."
 msgstr ""
 
 #: templates/_strings.html:43
-msgid "Rename Dataset Error!"
+msgid "Error: No datasets to export!"
 msgstr ""
 
 #: templates/_strings.html:44
-msgid "Dataset with this name already exists. Please pick a different name."
+msgid "Add Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:45
-msgid "Rename Axes Error!"
+msgid "Rename Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:46
-msgid "Axes with this name already exists. Please pick a different name."
+msgid "Dataset with this name already exists. Please pick a different name."
 msgstr ""
 
 #: templates/_strings.html:47
+msgid "Rename Axes Error!"
+msgstr ""
+
+#: templates/_strings.html:48
+msgid "Axes with this name already exists. Please pick a different name."
+msgstr ""
+
+#: templates/_strings.html:49
 msgid "Specify a valid number of datasets to add!"
 msgstr ""
 
-#: templates/_strings.html:49 templates/_tree.html:34
+#: templates/_strings.html:51 templates/_tree.html:34
 msgid "Datasets"
 msgstr ""
 
-#: templates/_strings.html:50 templates/_tree.html:42
+#: templates/_strings.html:52 templates/_tree.html:42
 msgid "Measurements"
 msgstr ""
 
-#: templates/_strings.html:51 templates/_tree.html:15 templates/_tree.html:25
+#: templates/_strings.html:53 templates/_tree.html:15 templates/_tree.html:25
 #: templates/_tree.html:53 templates/_tree.html:67 templates/_tree.html:84
 msgid "Axes"
 msgstr ""
 
-#: templates/_strings.html:53 templates/_tree.html:45 templates/_tree.html:74
+#: templates/_strings.html:55 templates/_tree.html:45 templates/_tree.html:74
 msgid "Angle"
 msgstr ""
 
-#: templates/_strings.html:54 templates/_tree.html:46 templates/_tree.html:82
+#: templates/_strings.html:56 templates/_tree.html:46 templates/_tree.html:82
 msgid "Area/Perimeter"
 msgstr ""
 
-#: templates/_strings.html:55
+#: templates/_strings.html:57
 msgid "XY"
 msgstr ""
 
-#: templates/_strings.html:57
+#: templates/_strings.html:59
 msgid "Bar"
 msgstr ""
 
-#: templates/_strings.html:58
+#: templates/_strings.html:60
 msgid "Polar"
 msgstr ""
 
-#: templates/_strings.html:59
+#: templates/_strings.html:61
 msgid "Ternary"
 msgstr ""
 
-#: templates/_strings.html:60
+#: templates/_strings.html:62
 msgid "Map"
 msgstr ""
 
-#: templates/_strings.html:61
+#: templates/_strings.html:63
 msgid "Circular Chart"
 msgstr ""
 
-#: templates/_strings.html:62
+#: templates/_strings.html:64
 msgid "Project"
 msgstr ""
 
-#: templates/_strings.html:63
+#: templates/_strings.html:65
 msgid "Distance Measurements"
 msgstr ""
 
-#: templates/_strings.html:64
+#: templates/_strings.html:66
 msgid "Angle Measurements"
 msgstr ""
 
-#: templates/_strings.html:65
+#: templates/_strings.html:67
 msgid "Area Measurements"
 msgstr ""
 
-#: templates/_strings.html:66
+#: templates/_strings.html:68
 msgid "Uncalibrated Dataset!"
 msgstr ""
 
-#: templates/_strings.html:67
+#: templates/_strings.html:69
 msgid "Assign an axes calibration to this dataset!"
 msgstr ""
 
-#: templates/_strings.html:68
+#: templates/_strings.html:70
 msgid "Invalid Project!"
 msgstr ""
 
-#: templates/_strings.html:69
+#: templates/_strings.html:71
 msgid "Not a valid project file format!"
 msgstr ""
 
-#: templates/_strings.html:71
+#: templates/_strings.html:73
 msgid "of"
 msgstr ""
 
-#: templates/_strings.html:72
+#: templates/_strings.html:74
 msgid "Page"
 msgstr ""
 
-#: templates/_strings.html:75
+#: templates/_strings.html:77
 msgid "Yes"
 msgstr ""
 
-#: templates/_strings.html:76
+#: templates/_strings.html:78
 msgid "No"
 msgstr ""
 
-#: templates/_strings.html:77
+#: templates/_strings.html:79
 msgid "Delete Point Tuple"
 msgstr ""
 
-#: templates/_strings.html:78
+#: templates/_strings.html:80
 msgid "Delete all points in the tuple?"
 msgstr ""
 
-#: templates/_strings.html:79 templates/_strings.html:82
+#: templates/_strings.html:81 templates/_strings.html:84
 msgid "Delete Group"
 msgstr ""
 
-#: templates/_strings.html:80
+#: templates/_strings.html:82
 msgid "Delete all points in deleted groups?"
 msgstr ""
 
-#: templates/_strings.html:84
+#: templates/_strings.html:86
 msgid "new tuple"
 msgstr ""
 

--- a/app/locale/ja/LC_MESSAGES/messages.po
+++ b/app/locale/ja/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-01 23:57-0800\n"
+"POT-Creation-Date: 2022-03-29 11:21-0400\n"
 "PO-Revision-Date: 2016-12-18 10:38-0600\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: templates/_base.html:27
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -112,7 +112,7 @@ msgstr ""
 #: templates/_popups.html:571 templates/_popups.html:583
 #: templates/_popups.html:594 templates/_popups.html:604
 #: templates/_popups.html:615 templates/_popups.html:647
-#: templates/_popups.html:697 templates/_strings.html:74
+#: templates/_popups.html:697 templates/_strings.html:76
 msgid "Cancel"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgstr ""
 #: templates/_popups.html:218 templates/_popups.html:256
 #: templates/_popups.html:283 templates/_popups.html:528
 #: templates/_popups.html:541 templates/_popups.html:555
-#: templates/_popups.html:627 templates/_strings.html:73
+#: templates/_popups.html:627 templates/_strings.html:75
 msgid "OK"
 msgstr ""
 
@@ -203,8 +203,8 @@ msgstr ""
 msgid "Map With Scale Bar"
 msgstr ""
 
-#: templates/_popups.html:112 templates/_strings.html:56
-#: templates/_strings.html:70 templates/_tree.html:8
+#: templates/_popups.html:112 templates/_strings.html:58
+#: templates/_strings.html:72 templates/_tree.html:8
 msgid "Image"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Acquired Data"
 msgstr ""
 
-#: templates/_popups.html:294 templates/_strings.html:48
+#: templates/_popups.html:294 templates/_strings.html:50
 #: templates/_tree.html:51
 msgid "Dataset"
 msgstr ""
@@ -776,11 +776,11 @@ msgid ""
 "-1. The process would repeat for the next set of points."
 msgstr ""
 
-#: templates/_popups.html:682 templates/_strings.html:81
+#: templates/_popups.html:682 templates/_strings.html:83
 msgid "Group"
 msgstr ""
 
-#: templates/_popups.html:685 templates/_strings.html:83
+#: templates/_popups.html:685 templates/_strings.html:85
 msgid "Primary Group"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Click to change color"
 msgstr ""
 
-#: templates/_sidebars.html:33 templates/_strings.html:52
+#: templates/_sidebars.html:33 templates/_strings.html:54
 #: templates/_tree.html:44 templates/_tree.html:65
 msgid "Distance"
 msgstr ""
@@ -1152,191 +1152,199 @@ msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
 #: templates/_strings.html:29
-msgid "Delete Axes"
+msgid "Delete Associated Datasets"
 msgstr ""
 
 #: templates/_strings.html:30
-msgid "Are you sure you want to delete this axes?"
+msgid "Delete all datasets associated with this axes?"
 msgstr ""
 
 #: templates/_strings.html:31
-msgid "Averaging Window"
+msgid "Delete Axes"
 msgstr ""
 
 #: templates/_strings.html:32
-msgid "X Step w/ Interpolation"
+msgid "Are you sure you want to delete this axes?"
 msgstr ""
 
 #: templates/_strings.html:33
-msgid "Custom Independents"
+msgid "Averaging Window"
 msgstr ""
 
 #: templates/_strings.html:34
-msgid "X Step"
+msgid "X Step w/ Interpolation"
 msgstr ""
 
 #: templates/_strings.html:35
-msgid "Blob Detector"
+msgid "Custom Independents"
 msgstr ""
 
 #: templates/_strings.html:36
-msgid "Bar Extraction"
+msgid "X Step"
 msgstr ""
 
 #: templates/_strings.html:37
-msgid "Histogram"
+msgid "Blob Detector"
 msgstr ""
 
 #: templates/_strings.html:38
-msgid "Specify Plot (Foreground) Color"
+msgid "Bar Extraction"
 msgstr ""
 
 #: templates/_strings.html:39
-msgid "Specify Background Color"
+msgid "Histogram"
 msgstr ""
 
 #: templates/_strings.html:40
-msgid "Please add some data before exporting."
+msgid "Specify Plot (Foreground) Color"
 msgstr ""
 
 #: templates/_strings.html:41
-msgid "Error: No datasets to export!"
+msgid "Specify Background Color"
 msgstr ""
 
 #: templates/_strings.html:42
-msgid "Add Dataset Error!"
+msgid "Please add some data before exporting."
 msgstr ""
 
 #: templates/_strings.html:43
-msgid "Rename Dataset Error!"
+msgid "Error: No datasets to export!"
 msgstr ""
 
 #: templates/_strings.html:44
-msgid "Dataset with this name already exists. Please pick a different name."
+msgid "Add Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:45
-msgid "Rename Axes Error!"
+msgid "Rename Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:46
-msgid "Axes with this name already exists. Please pick a different name."
+msgid "Dataset with this name already exists. Please pick a different name."
 msgstr ""
 
 #: templates/_strings.html:47
+msgid "Rename Axes Error!"
+msgstr ""
+
+#: templates/_strings.html:48
+msgid "Axes with this name already exists. Please pick a different name."
+msgstr ""
+
+#: templates/_strings.html:49
 msgid "Specify a valid number of datasets to add!"
 msgstr ""
 
-#: templates/_strings.html:49 templates/_tree.html:34
+#: templates/_strings.html:51 templates/_tree.html:34
 msgid "Datasets"
 msgstr ""
 
-#: templates/_strings.html:50 templates/_tree.html:42
+#: templates/_strings.html:52 templates/_tree.html:42
 msgid "Measurements"
 msgstr ""
 
-#: templates/_strings.html:51 templates/_tree.html:15 templates/_tree.html:25
+#: templates/_strings.html:53 templates/_tree.html:15 templates/_tree.html:25
 #: templates/_tree.html:53 templates/_tree.html:67 templates/_tree.html:84
 msgid "Axes"
 msgstr ""
 
-#: templates/_strings.html:53 templates/_tree.html:45 templates/_tree.html:74
+#: templates/_strings.html:55 templates/_tree.html:45 templates/_tree.html:74
 msgid "Angle"
 msgstr ""
 
-#: templates/_strings.html:54 templates/_tree.html:46 templates/_tree.html:82
+#: templates/_strings.html:56 templates/_tree.html:46 templates/_tree.html:82
 msgid "Area/Perimeter"
 msgstr ""
 
-#: templates/_strings.html:55
+#: templates/_strings.html:57
 msgid "XY"
 msgstr ""
 
-#: templates/_strings.html:57
+#: templates/_strings.html:59
 msgid "Bar"
 msgstr ""
 
-#: templates/_strings.html:58
+#: templates/_strings.html:60
 msgid "Polar"
 msgstr ""
 
-#: templates/_strings.html:59
+#: templates/_strings.html:61
 msgid "Ternary"
 msgstr ""
 
-#: templates/_strings.html:60
+#: templates/_strings.html:62
 msgid "Map"
 msgstr ""
 
-#: templates/_strings.html:61
+#: templates/_strings.html:63
 msgid "Circular Chart"
 msgstr ""
 
-#: templates/_strings.html:62
+#: templates/_strings.html:64
 msgid "Project"
 msgstr ""
 
-#: templates/_strings.html:63
+#: templates/_strings.html:65
 msgid "Distance Measurements"
 msgstr ""
 
-#: templates/_strings.html:64
+#: templates/_strings.html:66
 msgid "Angle Measurements"
 msgstr ""
 
-#: templates/_strings.html:65
+#: templates/_strings.html:67
 msgid "Area Measurements"
 msgstr ""
 
-#: templates/_strings.html:66
+#: templates/_strings.html:68
 msgid "Uncalibrated Dataset!"
 msgstr ""
 
-#: templates/_strings.html:67
+#: templates/_strings.html:69
 msgid "Assign an axes calibration to this dataset!"
 msgstr ""
 
-#: templates/_strings.html:68
+#: templates/_strings.html:70
 msgid "Invalid Project!"
 msgstr ""
 
-#: templates/_strings.html:69
+#: templates/_strings.html:71
 msgid "Not a valid project file format!"
 msgstr ""
 
-#: templates/_strings.html:71
+#: templates/_strings.html:73
 msgid "of"
 msgstr ""
 
-#: templates/_strings.html:72
+#: templates/_strings.html:74
 msgid "Page"
 msgstr ""
 
-#: templates/_strings.html:75
+#: templates/_strings.html:77
 msgid "Yes"
 msgstr ""
 
-#: templates/_strings.html:76
+#: templates/_strings.html:78
 msgid "No"
 msgstr ""
 
-#: templates/_strings.html:77
+#: templates/_strings.html:79
 msgid "Delete Point Tuple"
 msgstr ""
 
-#: templates/_strings.html:78
+#: templates/_strings.html:80
 msgid "Delete all points in the tuple?"
 msgstr ""
 
-#: templates/_strings.html:79 templates/_strings.html:82
+#: templates/_strings.html:81 templates/_strings.html:84
 msgid "Delete Group"
 msgstr ""
 
-#: templates/_strings.html:80
+#: templates/_strings.html:82
 msgid "Delete all points in deleted groups?"
 msgstr ""
 
-#: templates/_strings.html:84
+#: templates/_strings.html:86
 msgid "new tuple"
 msgstr ""
 

--- a/app/locale/messages.pot
+++ b/app/locale/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-01 23:57-0800\n"
+"POT-Creation-Date: 2022-03-29 11:21-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: templates/_base.html:27
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -111,7 +111,7 @@ msgstr ""
 #: templates/_popups.html:571 templates/_popups.html:583
 #: templates/_popups.html:594 templates/_popups.html:604
 #: templates/_popups.html:615 templates/_popups.html:647
-#: templates/_popups.html:697 templates/_strings.html:74
+#: templates/_popups.html:697 templates/_strings.html:76
 msgid "Cancel"
 msgstr ""
 
@@ -174,7 +174,7 @@ msgstr ""
 #: templates/_popups.html:218 templates/_popups.html:256
 #: templates/_popups.html:283 templates/_popups.html:528
 #: templates/_popups.html:541 templates/_popups.html:555
-#: templates/_popups.html:627 templates/_strings.html:73
+#: templates/_popups.html:627 templates/_strings.html:75
 msgid "OK"
 msgstr ""
 
@@ -202,8 +202,8 @@ msgstr ""
 msgid "Map With Scale Bar"
 msgstr ""
 
-#: templates/_popups.html:112 templates/_strings.html:56
-#: templates/_strings.html:70 templates/_tree.html:8
+#: templates/_popups.html:112 templates/_strings.html:58
+#: templates/_strings.html:72 templates/_tree.html:8
 msgid "Image"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Acquired Data"
 msgstr ""
 
-#: templates/_popups.html:294 templates/_strings.html:48
+#: templates/_popups.html:294 templates/_strings.html:50
 #: templates/_tree.html:51
 msgid "Dataset"
 msgstr ""
@@ -775,11 +775,11 @@ msgid ""
 "-1. The process would repeat for the next set of points."
 msgstr ""
 
-#: templates/_popups.html:682 templates/_strings.html:81
+#: templates/_popups.html:682 templates/_strings.html:83
 msgid "Group"
 msgstr ""
 
-#: templates/_popups.html:685 templates/_strings.html:83
+#: templates/_popups.html:685 templates/_strings.html:85
 msgid "Primary Group"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr ""
 msgid "Click to change color"
 msgstr ""
 
-#: templates/_sidebars.html:33 templates/_strings.html:52
+#: templates/_sidebars.html:33 templates/_strings.html:54
 #: templates/_tree.html:44 templates/_tree.html:65
 msgid "Distance"
 msgstr ""
@@ -1151,191 +1151,199 @@ msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
 #: templates/_strings.html:29
-msgid "Delete Axes"
+msgid "Delete Associated Datasets"
 msgstr ""
 
 #: templates/_strings.html:30
-msgid "Are you sure you want to delete this axes?"
+msgid "Delete all datasets associated with this axes?"
 msgstr ""
 
 #: templates/_strings.html:31
-msgid "Averaging Window"
+msgid "Delete Axes"
 msgstr ""
 
 #: templates/_strings.html:32
-msgid "X Step w/ Interpolation"
+msgid "Are you sure you want to delete this axes?"
 msgstr ""
 
 #: templates/_strings.html:33
-msgid "Custom Independents"
+msgid "Averaging Window"
 msgstr ""
 
 #: templates/_strings.html:34
-msgid "X Step"
+msgid "X Step w/ Interpolation"
 msgstr ""
 
 #: templates/_strings.html:35
-msgid "Blob Detector"
+msgid "Custom Independents"
 msgstr ""
 
 #: templates/_strings.html:36
-msgid "Bar Extraction"
+msgid "X Step"
 msgstr ""
 
 #: templates/_strings.html:37
-msgid "Histogram"
+msgid "Blob Detector"
 msgstr ""
 
 #: templates/_strings.html:38
-msgid "Specify Plot (Foreground) Color"
+msgid "Bar Extraction"
 msgstr ""
 
 #: templates/_strings.html:39
-msgid "Specify Background Color"
+msgid "Histogram"
 msgstr ""
 
 #: templates/_strings.html:40
-msgid "Please add some data before exporting."
+msgid "Specify Plot (Foreground) Color"
 msgstr ""
 
 #: templates/_strings.html:41
-msgid "Error: No datasets to export!"
+msgid "Specify Background Color"
 msgstr ""
 
 #: templates/_strings.html:42
-msgid "Add Dataset Error!"
+msgid "Please add some data before exporting."
 msgstr ""
 
 #: templates/_strings.html:43
-msgid "Rename Dataset Error!"
+msgid "Error: No datasets to export!"
 msgstr ""
 
 #: templates/_strings.html:44
-msgid "Dataset with this name already exists. Please pick a different name."
+msgid "Add Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:45
-msgid "Rename Axes Error!"
+msgid "Rename Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:46
-msgid "Axes with this name already exists. Please pick a different name."
+msgid "Dataset with this name already exists. Please pick a different name."
 msgstr ""
 
 #: templates/_strings.html:47
+msgid "Rename Axes Error!"
+msgstr ""
+
+#: templates/_strings.html:48
+msgid "Axes with this name already exists. Please pick a different name."
+msgstr ""
+
+#: templates/_strings.html:49
 msgid "Specify a valid number of datasets to add!"
 msgstr ""
 
-#: templates/_strings.html:49 templates/_tree.html:34
+#: templates/_strings.html:51 templates/_tree.html:34
 msgid "Datasets"
 msgstr ""
 
-#: templates/_strings.html:50 templates/_tree.html:42
+#: templates/_strings.html:52 templates/_tree.html:42
 msgid "Measurements"
 msgstr ""
 
-#: templates/_strings.html:51 templates/_tree.html:15 templates/_tree.html:25
+#: templates/_strings.html:53 templates/_tree.html:15 templates/_tree.html:25
 #: templates/_tree.html:53 templates/_tree.html:67 templates/_tree.html:84
 msgid "Axes"
 msgstr ""
 
-#: templates/_strings.html:53 templates/_tree.html:45 templates/_tree.html:74
+#: templates/_strings.html:55 templates/_tree.html:45 templates/_tree.html:74
 msgid "Angle"
 msgstr ""
 
-#: templates/_strings.html:54 templates/_tree.html:46 templates/_tree.html:82
+#: templates/_strings.html:56 templates/_tree.html:46 templates/_tree.html:82
 msgid "Area/Perimeter"
 msgstr ""
 
-#: templates/_strings.html:55
+#: templates/_strings.html:57
 msgid "XY"
 msgstr ""
 
-#: templates/_strings.html:57
+#: templates/_strings.html:59
 msgid "Bar"
 msgstr ""
 
-#: templates/_strings.html:58
+#: templates/_strings.html:60
 msgid "Polar"
 msgstr ""
 
-#: templates/_strings.html:59
+#: templates/_strings.html:61
 msgid "Ternary"
 msgstr ""
 
-#: templates/_strings.html:60
+#: templates/_strings.html:62
 msgid "Map"
 msgstr ""
 
-#: templates/_strings.html:61
+#: templates/_strings.html:63
 msgid "Circular Chart"
 msgstr ""
 
-#: templates/_strings.html:62
+#: templates/_strings.html:64
 msgid "Project"
 msgstr ""
 
-#: templates/_strings.html:63
+#: templates/_strings.html:65
 msgid "Distance Measurements"
 msgstr ""
 
-#: templates/_strings.html:64
+#: templates/_strings.html:66
 msgid "Angle Measurements"
 msgstr ""
 
-#: templates/_strings.html:65
+#: templates/_strings.html:67
 msgid "Area Measurements"
 msgstr ""
 
-#: templates/_strings.html:66
+#: templates/_strings.html:68
 msgid "Uncalibrated Dataset!"
 msgstr ""
 
-#: templates/_strings.html:67
+#: templates/_strings.html:69
 msgid "Assign an axes calibration to this dataset!"
 msgstr ""
 
-#: templates/_strings.html:68
+#: templates/_strings.html:70
 msgid "Invalid Project!"
 msgstr ""
 
-#: templates/_strings.html:69
+#: templates/_strings.html:71
 msgid "Not a valid project file format!"
 msgstr ""
 
-#: templates/_strings.html:71
+#: templates/_strings.html:73
 msgid "of"
 msgstr ""
 
-#: templates/_strings.html:72
+#: templates/_strings.html:74
 msgid "Page"
 msgstr ""
 
-#: templates/_strings.html:75
+#: templates/_strings.html:77
 msgid "Yes"
 msgstr ""
 
-#: templates/_strings.html:76
+#: templates/_strings.html:78
 msgid "No"
 msgstr ""
 
-#: templates/_strings.html:77
+#: templates/_strings.html:79
 msgid "Delete Point Tuple"
 msgstr ""
 
-#: templates/_strings.html:78
+#: templates/_strings.html:80
 msgid "Delete all points in the tuple?"
 msgstr ""
 
-#: templates/_strings.html:79 templates/_strings.html:82
+#: templates/_strings.html:81 templates/_strings.html:84
 msgid "Delete Group"
 msgstr ""
 
-#: templates/_strings.html:80
+#: templates/_strings.html:82
 msgid "Delete all points in deleted groups?"
 msgstr ""
 
-#: templates/_strings.html:84
+#: templates/_strings.html:86
 msgid "new tuple"
 msgstr ""
 

--- a/app/locale/ru/LC_MESSAGES/messages.po
+++ b/app/locale/ru/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-01 23:57-0800\n"
+"POT-Creation-Date: 2022-03-29 11:21-0400\n"
 "PO-Revision-Date: 2016-12-18 10:38-0600\n"
 "Last-Translator: \n"
 "Language: ru\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: templates/_base.html:27
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -113,7 +113,7 @@ msgstr ""
 #: templates/_popups.html:571 templates/_popups.html:583
 #: templates/_popups.html:594 templates/_popups.html:604
 #: templates/_popups.html:615 templates/_popups.html:647
-#: templates/_popups.html:697 templates/_strings.html:74
+#: templates/_popups.html:697 templates/_strings.html:76
 msgid "Cancel"
 msgstr ""
 
@@ -176,7 +176,7 @@ msgstr ""
 #: templates/_popups.html:218 templates/_popups.html:256
 #: templates/_popups.html:283 templates/_popups.html:528
 #: templates/_popups.html:541 templates/_popups.html:555
-#: templates/_popups.html:627 templates/_strings.html:73
+#: templates/_popups.html:627 templates/_strings.html:75
 msgid "OK"
 msgstr ""
 
@@ -204,8 +204,8 @@ msgstr ""
 msgid "Map With Scale Bar"
 msgstr ""
 
-#: templates/_popups.html:112 templates/_strings.html:56
-#: templates/_strings.html:70 templates/_tree.html:8
+#: templates/_popups.html:112 templates/_strings.html:58
+#: templates/_strings.html:72 templates/_tree.html:8
 msgid "Image"
 msgstr ""
 
@@ -345,7 +345,7 @@ msgstr ""
 msgid "Acquired Data"
 msgstr ""
 
-#: templates/_popups.html:294 templates/_strings.html:48
+#: templates/_popups.html:294 templates/_strings.html:50
 #: templates/_tree.html:51
 msgid "Dataset"
 msgstr ""
@@ -777,11 +777,11 @@ msgid ""
 "-1. The process would repeat for the next set of points."
 msgstr ""
 
-#: templates/_popups.html:682 templates/_strings.html:81
+#: templates/_popups.html:682 templates/_strings.html:83
 msgid "Group"
 msgstr ""
 
-#: templates/_popups.html:685 templates/_strings.html:83
+#: templates/_popups.html:685 templates/_strings.html:85
 msgid "Primary Group"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Click to change color"
 msgstr ""
 
-#: templates/_sidebars.html:33 templates/_strings.html:52
+#: templates/_sidebars.html:33 templates/_strings.html:54
 #: templates/_tree.html:44 templates/_tree.html:65
 msgid "Distance"
 msgstr ""
@@ -1153,191 +1153,199 @@ msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
 #: templates/_strings.html:29
-msgid "Delete Axes"
+msgid "Delete Associated Datasets"
 msgstr ""
 
 #: templates/_strings.html:30
-msgid "Are you sure you want to delete this axes?"
+msgid "Delete all datasets associated with this axes?"
 msgstr ""
 
 #: templates/_strings.html:31
-msgid "Averaging Window"
+msgid "Delete Axes"
 msgstr ""
 
 #: templates/_strings.html:32
-msgid "X Step w/ Interpolation"
+msgid "Are you sure you want to delete this axes?"
 msgstr ""
 
 #: templates/_strings.html:33
-msgid "Custom Independents"
+msgid "Averaging Window"
 msgstr ""
 
 #: templates/_strings.html:34
-msgid "X Step"
+msgid "X Step w/ Interpolation"
 msgstr ""
 
 #: templates/_strings.html:35
-msgid "Blob Detector"
+msgid "Custom Independents"
 msgstr ""
 
 #: templates/_strings.html:36
-msgid "Bar Extraction"
+msgid "X Step"
 msgstr ""
 
 #: templates/_strings.html:37
-msgid "Histogram"
+msgid "Blob Detector"
 msgstr ""
 
 #: templates/_strings.html:38
-msgid "Specify Plot (Foreground) Color"
+msgid "Bar Extraction"
 msgstr ""
 
 #: templates/_strings.html:39
-msgid "Specify Background Color"
+msgid "Histogram"
 msgstr ""
 
 #: templates/_strings.html:40
-msgid "Please add some data before exporting."
+msgid "Specify Plot (Foreground) Color"
 msgstr ""
 
 #: templates/_strings.html:41
-msgid "Error: No datasets to export!"
+msgid "Specify Background Color"
 msgstr ""
 
 #: templates/_strings.html:42
-msgid "Add Dataset Error!"
+msgid "Please add some data before exporting."
 msgstr ""
 
 #: templates/_strings.html:43
-msgid "Rename Dataset Error!"
+msgid "Error: No datasets to export!"
 msgstr ""
 
 #: templates/_strings.html:44
-msgid "Dataset with this name already exists. Please pick a different name."
+msgid "Add Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:45
-msgid "Rename Axes Error!"
+msgid "Rename Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:46
-msgid "Axes with this name already exists. Please pick a different name."
+msgid "Dataset with this name already exists. Please pick a different name."
 msgstr ""
 
 #: templates/_strings.html:47
+msgid "Rename Axes Error!"
+msgstr ""
+
+#: templates/_strings.html:48
+msgid "Axes with this name already exists. Please pick a different name."
+msgstr ""
+
+#: templates/_strings.html:49
 msgid "Specify a valid number of datasets to add!"
 msgstr ""
 
-#: templates/_strings.html:49 templates/_tree.html:34
+#: templates/_strings.html:51 templates/_tree.html:34
 msgid "Datasets"
 msgstr ""
 
-#: templates/_strings.html:50 templates/_tree.html:42
+#: templates/_strings.html:52 templates/_tree.html:42
 msgid "Measurements"
 msgstr ""
 
-#: templates/_strings.html:51 templates/_tree.html:15 templates/_tree.html:25
+#: templates/_strings.html:53 templates/_tree.html:15 templates/_tree.html:25
 #: templates/_tree.html:53 templates/_tree.html:67 templates/_tree.html:84
 msgid "Axes"
 msgstr ""
 
-#: templates/_strings.html:53 templates/_tree.html:45 templates/_tree.html:74
+#: templates/_strings.html:55 templates/_tree.html:45 templates/_tree.html:74
 msgid "Angle"
 msgstr ""
 
-#: templates/_strings.html:54 templates/_tree.html:46 templates/_tree.html:82
+#: templates/_strings.html:56 templates/_tree.html:46 templates/_tree.html:82
 msgid "Area/Perimeter"
 msgstr ""
 
-#: templates/_strings.html:55
+#: templates/_strings.html:57
 msgid "XY"
 msgstr ""
 
-#: templates/_strings.html:57
+#: templates/_strings.html:59
 msgid "Bar"
 msgstr ""
 
-#: templates/_strings.html:58
+#: templates/_strings.html:60
 msgid "Polar"
 msgstr ""
 
-#: templates/_strings.html:59
+#: templates/_strings.html:61
 msgid "Ternary"
 msgstr ""
 
-#: templates/_strings.html:60
+#: templates/_strings.html:62
 msgid "Map"
 msgstr ""
 
-#: templates/_strings.html:61
+#: templates/_strings.html:63
 msgid "Circular Chart"
 msgstr ""
 
-#: templates/_strings.html:62
+#: templates/_strings.html:64
 msgid "Project"
 msgstr ""
 
-#: templates/_strings.html:63
+#: templates/_strings.html:65
 msgid "Distance Measurements"
 msgstr ""
 
-#: templates/_strings.html:64
+#: templates/_strings.html:66
 msgid "Angle Measurements"
 msgstr ""
 
-#: templates/_strings.html:65
+#: templates/_strings.html:67
 msgid "Area Measurements"
 msgstr ""
 
-#: templates/_strings.html:66
+#: templates/_strings.html:68
 msgid "Uncalibrated Dataset!"
 msgstr ""
 
-#: templates/_strings.html:67
+#: templates/_strings.html:69
 msgid "Assign an axes calibration to this dataset!"
 msgstr ""
 
-#: templates/_strings.html:68
+#: templates/_strings.html:70
 msgid "Invalid Project!"
 msgstr ""
 
-#: templates/_strings.html:69
+#: templates/_strings.html:71
 msgid "Not a valid project file format!"
 msgstr ""
 
-#: templates/_strings.html:71
+#: templates/_strings.html:73
 msgid "of"
 msgstr ""
 
-#: templates/_strings.html:72
+#: templates/_strings.html:74
 msgid "Page"
 msgstr ""
 
-#: templates/_strings.html:75
+#: templates/_strings.html:77
 msgid "Yes"
 msgstr ""
 
-#: templates/_strings.html:76
+#: templates/_strings.html:78
 msgid "No"
 msgstr ""
 
-#: templates/_strings.html:77
+#: templates/_strings.html:79
 msgid "Delete Point Tuple"
 msgstr ""
 
-#: templates/_strings.html:78
+#: templates/_strings.html:80
 msgid "Delete all points in the tuple?"
 msgstr ""
 
-#: templates/_strings.html:79 templates/_strings.html:82
+#: templates/_strings.html:81 templates/_strings.html:84
 msgid "Delete Group"
 msgstr ""
 
-#: templates/_strings.html:80
+#: templates/_strings.html:82
 msgid "Delete all points in deleted groups?"
 msgstr ""
 
-#: templates/_strings.html:84
+#: templates/_strings.html:86
 msgid "new tuple"
 msgstr ""
 

--- a/app/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/app/locale/zh_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  WebPlotDigitizer\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-01 23:57-0800\n"
+"POT-Creation-Date: 2022-03-29 11:21-0400\n"
 "PO-Revision-Date: 2018-02-21 00:47-0600\n"
 "Last-Translator: RGXGR <rgxgr@outlook.com>\n"
 "Language: zh_Hans_CN\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.9.0\n"
 
 #: templates/_base.html:27
 msgid "Web based tool to extract numerical data from plots and graph images."
@@ -112,7 +112,7 @@ msgstr ""
 #: templates/_popups.html:571 templates/_popups.html:583
 #: templates/_popups.html:594 templates/_popups.html:604
 #: templates/_popups.html:615 templates/_popups.html:647
-#: templates/_popups.html:697 templates/_strings.html:74
+#: templates/_popups.html:697 templates/_strings.html:76
 msgid "Cancel"
 msgstr ""
 
@@ -175,7 +175,7 @@ msgstr ""
 #: templates/_popups.html:218 templates/_popups.html:256
 #: templates/_popups.html:283 templates/_popups.html:528
 #: templates/_popups.html:541 templates/_popups.html:555
-#: templates/_popups.html:627 templates/_strings.html:73
+#: templates/_popups.html:627 templates/_strings.html:75
 msgid "OK"
 msgstr ""
 
@@ -203,8 +203,8 @@ msgstr ""
 msgid "Map With Scale Bar"
 msgstr ""
 
-#: templates/_popups.html:112 templates/_strings.html:56
-#: templates/_strings.html:70 templates/_tree.html:8
+#: templates/_popups.html:112 templates/_strings.html:58
+#: templates/_strings.html:72 templates/_tree.html:8
 msgid "Image"
 msgstr ""
 
@@ -344,7 +344,7 @@ msgstr ""
 msgid "Acquired Data"
 msgstr ""
 
-#: templates/_popups.html:294 templates/_strings.html:48
+#: templates/_popups.html:294 templates/_strings.html:50
 #: templates/_tree.html:51
 msgid "Dataset"
 msgstr ""
@@ -776,11 +776,11 @@ msgid ""
 "-1. The process would repeat for the next set of points."
 msgstr ""
 
-#: templates/_popups.html:682 templates/_strings.html:81
+#: templates/_popups.html:682 templates/_strings.html:83
 msgid "Group"
 msgstr ""
 
-#: templates/_popups.html:685 templates/_strings.html:83
+#: templates/_popups.html:685 templates/_strings.html:85
 msgid "Primary Group"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Click to change color"
 msgstr ""
 
-#: templates/_sidebars.html:33 templates/_strings.html:52
+#: templates/_sidebars.html:33 templates/_strings.html:54
 #: templates/_tree.html:44 templates/_tree.html:65
 msgid "Distance"
 msgstr ""
@@ -1152,191 +1152,199 @@ msgid "Are you sure you want to delete this dataset?"
 msgstr ""
 
 #: templates/_strings.html:29
-msgid "Delete Axes"
+msgid "Delete Associated Datasets"
 msgstr ""
 
 #: templates/_strings.html:30
-msgid "Are you sure you want to delete this axes?"
+msgid "Delete all datasets associated with this axes?"
 msgstr ""
 
 #: templates/_strings.html:31
-msgid "Averaging Window"
+msgid "Delete Axes"
 msgstr ""
 
 #: templates/_strings.html:32
-msgid "X Step w/ Interpolation"
+msgid "Are you sure you want to delete this axes?"
 msgstr ""
 
 #: templates/_strings.html:33
-msgid "Custom Independents"
+msgid "Averaging Window"
 msgstr ""
 
 #: templates/_strings.html:34
-msgid "X Step"
+msgid "X Step w/ Interpolation"
 msgstr ""
 
 #: templates/_strings.html:35
-msgid "Blob Detector"
+msgid "Custom Independents"
 msgstr ""
 
 #: templates/_strings.html:36
-msgid "Bar Extraction"
+msgid "X Step"
 msgstr ""
 
 #: templates/_strings.html:37
-msgid "Histogram"
+msgid "Blob Detector"
 msgstr ""
 
 #: templates/_strings.html:38
-msgid "Specify Plot (Foreground) Color"
+msgid "Bar Extraction"
 msgstr ""
 
 #: templates/_strings.html:39
-msgid "Specify Background Color"
+msgid "Histogram"
 msgstr ""
 
 #: templates/_strings.html:40
-msgid "Please add some data before exporting."
+msgid "Specify Plot (Foreground) Color"
 msgstr ""
 
 #: templates/_strings.html:41
-msgid "Error: No datasets to export!"
+msgid "Specify Background Color"
 msgstr ""
 
 #: templates/_strings.html:42
-msgid "Add Dataset Error!"
+msgid "Please add some data before exporting."
 msgstr ""
 
 #: templates/_strings.html:43
-msgid "Rename Dataset Error!"
+msgid "Error: No datasets to export!"
 msgstr ""
 
 #: templates/_strings.html:44
-msgid "Dataset with this name already exists. Please pick a different name."
+msgid "Add Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:45
-msgid "Rename Axes Error!"
+msgid "Rename Dataset Error!"
 msgstr ""
 
 #: templates/_strings.html:46
-msgid "Axes with this name already exists. Please pick a different name."
+msgid "Dataset with this name already exists. Please pick a different name."
 msgstr ""
 
 #: templates/_strings.html:47
+msgid "Rename Axes Error!"
+msgstr ""
+
+#: templates/_strings.html:48
+msgid "Axes with this name already exists. Please pick a different name."
+msgstr ""
+
+#: templates/_strings.html:49
 msgid "Specify a valid number of datasets to add!"
 msgstr ""
 
-#: templates/_strings.html:49 templates/_tree.html:34
+#: templates/_strings.html:51 templates/_tree.html:34
 msgid "Datasets"
 msgstr ""
 
-#: templates/_strings.html:50 templates/_tree.html:42
+#: templates/_strings.html:52 templates/_tree.html:42
 msgid "Measurements"
 msgstr ""
 
-#: templates/_strings.html:51 templates/_tree.html:15 templates/_tree.html:25
+#: templates/_strings.html:53 templates/_tree.html:15 templates/_tree.html:25
 #: templates/_tree.html:53 templates/_tree.html:67 templates/_tree.html:84
 msgid "Axes"
 msgstr ""
 
-#: templates/_strings.html:53 templates/_tree.html:45 templates/_tree.html:74
+#: templates/_strings.html:55 templates/_tree.html:45 templates/_tree.html:74
 msgid "Angle"
 msgstr ""
 
-#: templates/_strings.html:54 templates/_tree.html:46 templates/_tree.html:82
+#: templates/_strings.html:56 templates/_tree.html:46 templates/_tree.html:82
 msgid "Area/Perimeter"
 msgstr ""
 
-#: templates/_strings.html:55
+#: templates/_strings.html:57
 msgid "XY"
 msgstr ""
 
-#: templates/_strings.html:57
+#: templates/_strings.html:59
 msgid "Bar"
 msgstr ""
 
-#: templates/_strings.html:58
+#: templates/_strings.html:60
 msgid "Polar"
 msgstr ""
 
-#: templates/_strings.html:59
+#: templates/_strings.html:61
 msgid "Ternary"
 msgstr ""
 
-#: templates/_strings.html:60
+#: templates/_strings.html:62
 msgid "Map"
 msgstr ""
 
-#: templates/_strings.html:61
+#: templates/_strings.html:63
 msgid "Circular Chart"
 msgstr ""
 
-#: templates/_strings.html:62
+#: templates/_strings.html:64
 msgid "Project"
 msgstr ""
 
-#: templates/_strings.html:63
+#: templates/_strings.html:65
 msgid "Distance Measurements"
 msgstr ""
 
-#: templates/_strings.html:64
+#: templates/_strings.html:66
 msgid "Angle Measurements"
 msgstr ""
 
-#: templates/_strings.html:65
+#: templates/_strings.html:67
 msgid "Area Measurements"
 msgstr ""
 
-#: templates/_strings.html:66
+#: templates/_strings.html:68
 msgid "Uncalibrated Dataset!"
 msgstr ""
 
-#: templates/_strings.html:67
+#: templates/_strings.html:69
 msgid "Assign an axes calibration to this dataset!"
 msgstr ""
 
-#: templates/_strings.html:68
+#: templates/_strings.html:70
 msgid "Invalid Project!"
 msgstr ""
 
-#: templates/_strings.html:69
+#: templates/_strings.html:71
 msgid "Not a valid project file format!"
 msgstr ""
 
-#: templates/_strings.html:71
+#: templates/_strings.html:73
 msgid "of"
 msgstr ""
 
-#: templates/_strings.html:72
+#: templates/_strings.html:74
 msgid "Page"
 msgstr ""
 
-#: templates/_strings.html:75
+#: templates/_strings.html:77
 msgid "Yes"
 msgstr ""
 
-#: templates/_strings.html:76
+#: templates/_strings.html:78
 msgid "No"
 msgstr ""
 
-#: templates/_strings.html:77
+#: templates/_strings.html:79
 msgid "Delete Point Tuple"
 msgstr ""
 
-#: templates/_strings.html:78
+#: templates/_strings.html:80
 msgid "Delete all points in the tuple?"
 msgstr ""
 
-#: templates/_strings.html:79 templates/_strings.html:82
+#: templates/_strings.html:81 templates/_strings.html:84
 msgid "Delete Group"
 msgstr ""
 
-#: templates/_strings.html:80
+#: templates/_strings.html:82
 msgid "Delete all points in deleted groups?"
 msgstr ""
 
-#: templates/_strings.html:84
+#: templates/_strings.html:86
 msgid "new tuple"
 msgstr ""
 

--- a/app/templates/_strings.html
+++ b/app/templates/_strings.html
@@ -26,6 +26,8 @@
 <div class="i18n-string" id="i18n-string-manage-datasets-text">{{ _("Please calibrate the axes before managing datasets.") }}</div>
 <div class="i18n-string" id="i18n-string-delete-dataset">{{ _("Delete Dataset") }}</div>
 <div class="i18n-string" id="i18n-string-delete-dataset-text">{{ _("Are you sure you want to delete this dataset?") }}</div>
+<div class="i18n-string" id="i18n-string-delete-associated-datasets">{{ _("Delete Associated Datasets") }}</div>
+<div class="i18n-string" id="i18n-string-delete-associated-datasets-text">{{ _("Delete all datasets associated with this axes?") }}</div>
 <div class="i18n-string" id="i18n-string-delete-axes">{{ _("Delete Axes") }}</div>
 <div class="i18n-string" id="i18n-string-delete-axes-text">{{ _("Are you sure you want to delete this axes?") }}</div>
 <div class="i18n-string" id="i18n-string-averaging-window">{{ _("Averaging Window") }}</div>


### PR DESCRIPTION
Hey Ankit, got a small workflow convenience here. Added a popup to give users an option to delete associated datasets while deleting an axis.

The new "Delete Associated Datasets" popup will display when:
- User clicks on "OK" in the "Delete Axes" popup, and
- Active axes has datasets associated to it.

Clicking on "OK" in the new popup will delete the associated datasets as well as the axes.
Clicking on "Cancel" in the new popup will not delete the associated datasets and will only delete the axes.