### PR TITLE
Image rotation and running unit tests from the command-line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 /app/node_modules/*
 /app/package-lock.json
 
+# app directory exclusion exceptions
+!/app/karma.conf.js
+
 # electron directory exclusions
 /electron/node_modules/
 /electron/package-lock.json

--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -88,21 +88,53 @@ This will create apps for Mac, Windows and Linux.
 
 Please consider adding unit tests when adding or editing code. Any contributions to increase existing code coverage is greatly appreciated.
 
-Unit tests are located in the `app/tests` directory. The tests are written for [QUnit](https://api.qunitjs.com/). The mocking library [Sinon.js](https://sinonjs.org/) is included as well to facilitate unit test creation.
+Unit tests are located in the `app/tests` directory. The tests are written for [QUnit](https://api.qunitjs.com/). The test runner [Karma](https://karma-runner.github.io/) is used to enable command-line results. The mocking library [Sinon.js](https://sinonjs.org/) is included as well to facilitate unit test creation.
 
-To run the tests, start a development server and append `/tests` to the url (e.g. `http://localhost:8080/tests`).
+**Adding tests**
+
+To add tests, locate the appropriate test file under `app/tests` (or create an appropriate file) and add the tests there.
+
+This isn't always possible, but ideally, each unit test assertion should complete execution within 10ms.
+
+**Running tests**
+
+To run the tests, use the following commands:
+
+    cd app
+    npm test
 
 This will load the QUnit tests, run them, and display the results.
 
-To add new unit tests, add or edit an existing test script. If adding a new script, make sure to include it in `app/tests/index.html` via an HTML `script` tag so the new script is included.
+To view the QUnit results in the browser, start a development server and append `/tests` to the url (e.g. `http://localhost:8080/tests`).
 
-This isn't always possible, but ideally, each test assertion should complete execution within 10ms.
+**Testing different browsers**
+
+To run the unit tests in different browsers, use this command:
+
+    npm test -- --browsers [browser-name]
+
+Note: `[browser-name]` is sentence-cased (e.g. Chrome).
+
+Or, alternatively, edit `karma.conf.js`, uncomment all desired browsers to concurrently run tests on under `browsers`, and re-run the tests.
+
+Karma can run the tests on a plethora of browsers. To use another browser, visit https://karma-runner.github.io/latest/config/browsers.html for more information on how to set it up. This typically involves having the desired browser installed on your local machine, and a Karma plugin for the browser. By default, Karma plugins for Chrome, Firefox, and Edge are already installed.
+
+**Auto-watch**
+
+Karma has been configured to run in single-run mode. But Karma has the ability to watch files for changes and re-run tests. To enable this behavior, run the following instead of `npm test`:
+
+    npm test -- --single-run false
 
 ## Coding Style
 
 - **Javascript**: ES6 with [AirBnB's style guide](https://github.com/airbnb/javascript) is recommended. A lot of older code does not follow this style and should be updated eventually.
 
-To run automatic formatting on the Javascript and C++ code, run the [format.sh](app/format.sh) script in the `app` folder.
+To run automatic formatting on the Javascript and C++ code, use this command:
+
+    cd app
+    npm run format
+
+Or, alternatively, run the [format.sh](app/format.sh) script in the `app` folder.
 
 ## Scripts
 

--- a/app/javascript/controllers/axesCalibration.js
+++ b/app/javascript/controllers/axesCalibration.js
@@ -568,8 +568,7 @@ wpd.alignAxes = (function() {
                 },
                 deleteAxes,
             );
-        }
-        else {
+        } else {
             // otherwise, proceed to delete the axes
             deleteAxes();
         }

--- a/app/javascript/controllers/imageEditing.js
+++ b/app/javascript/controllers/imageEditing.js
@@ -77,10 +77,13 @@ wpd.CropImageAction = class extends wpd.ReversibleAction {
         let imageSize = wpd.graphicsWidget.getImageSize();
         this._originalImage = ctx.oriImageCtx.getImageData(0, 0, imageSize.width, imageSize.height);
 
+        const width = this._x1 - this._x0;
+        const height = this._y1 - this._y0;
+
         // crop image
-        let croppedImage = ctx.oriImageCtx.getImageData(this._x0, this._y0, this._x1, this._y1);
-        let croppedWidth = this._x1 - this._x0;
-        let croppedHeight = this._y1 - this._y0;
+        let croppedImage = ctx.oriImageCtx.getImageData(this._x0, this._y0, width, height);
+        let croppedWidth = Math.abs(width);
+        let croppedHeight = Math.abs(height);
 
         // replace current image with cropped image
         let imageOp = function(imageData, width, height) {

--- a/app/javascript/controllers/imageManager.js
+++ b/app/javascript/controllers/imageManager.js
@@ -95,6 +95,10 @@ wpd.imageManager = (function() {
             wpd.appData.reset();
             wpd.sidebar.clear();
         }
+        const pageManager = wpd.appData.getPageManager();
+        if (pageManager) {
+            wpd.graphicsWidget.setRotation(pageManager.getRotation());
+        }
         let imageData = wpd.graphicsWidget.loadImage(image);
         wpd.appData.plotLoaded(imageData);
         wpd.busyNote.close();

--- a/app/javascript/tools/axesCalibrationTools.js
+++ b/app/javascript/tools/axesCalibrationTools.js
@@ -71,21 +71,34 @@ wpd.AxesCornersTool = (function() {
                 stepSize = ev.shiftKey === true ? 5 / wpd.graphicsWidget.getZoomRatio() :
                 0.5 / wpd.graphicsWidget.getZoomRatio();
 
+            // rotate to current rotation
+            const currentRotation = wpd.graphicsWidget.getRotation();
+            let {
+                x,
+                y
+            } = wpd.graphicsWidget.getRotatedCoordinates(0, currentRotation, pointPx, pointPy);
+
             if (wpd.keyCodes.isUp(ev.keyCode)) {
-                pointPy = pointPy - stepSize;
+                y = y - stepSize;
             } else if (wpd.keyCodes.isDown(ev.keyCode)) {
-                pointPy = pointPy + stepSize;
+                y = y + stepSize;
             } else if (wpd.keyCodes.isLeft(ev.keyCode)) {
-                pointPx = pointPx - stepSize;
+                x = x - stepSize;
             } else if (wpd.keyCodes.isRight(ev.keyCode)) {
-                pointPx = pointPx + stepSize;
+                x = x + stepSize;
             } else {
                 return;
             }
 
-            _calibration.changePointPx(_calibration.getSelectedPoints()[0], pointPx, pointPy);
+            // rotate back to original rotation
+            ({
+                x,
+                y
+            } = wpd.graphicsWidget.getRotatedCoordinates(currentRotation, 0, x, y));
+
+            _calibration.changePointPx(_calibration.getSelectedPoints()[0], x, y);
             wpd.graphicsWidget.forceHandlerRepaint();
-            wpd.graphicsWidget.updateZoomToImagePosn(pointPx, pointPy);
+            wpd.graphicsWidget.updateZoomToImagePosn(x, y);
             ev.preventDefault();
             ev.stopPropagation();
         };

--- a/app/javascript/tools/manualDetectionTools.js
+++ b/app/javascript/tools/manualDetectionTools.js
@@ -129,14 +129,21 @@ wpd.ManualSelectionTool = (function() {
                 lastPt = dataset.getPixel(lastPtIndex),
                 stepSize = 0.5 / wpd.graphicsWidget.getZoomRatio();
 
+            // rotate to current rotation
+            const currentRotation = wpd.graphicsWidget.getRotation();
+            let {
+                x,
+                y
+            } = wpd.graphicsWidget.getRotatedCoordinates(0, currentRotation, lastPt.x, lastPt.y);
+
             if (wpd.keyCodes.isUp(ev.keyCode)) {
-                lastPt.y = lastPt.y - stepSize;
+                y = y - stepSize;
             } else if (wpd.keyCodes.isDown(ev.keyCode)) {
-                lastPt.y = lastPt.y + stepSize;
+                y = y + stepSize;
             } else if (wpd.keyCodes.isLeft(ev.keyCode)) {
-                lastPt.x = lastPt.x - stepSize;
+                x = x - stepSize;
             } else if (wpd.keyCodes.isRight(ev.keyCode)) {
-                lastPt.x = lastPt.x + stepSize;
+                x = x + stepSize;
             } else if (wpd.keyCodes.isComma(ev.keyCode)) {
                 wpd.pointGroups.previousGroup();
                 return;
@@ -150,7 +157,13 @@ wpd.ManualSelectionTool = (function() {
                 return;
             }
 
-            dataset.setPixelAt(lastPtIndex, lastPt.x, lastPt.y);
+            // rotate back to original rotation
+            ({
+                x,
+                y
+            } = wpd.graphicsWidget.getRotatedCoordinates(currentRotation, 0, x, y));
+
+            dataset.setPixelAt(lastPtIndex, x, y);
             wpd.graphicsWidget.resetData();
             wpd.graphicsWidget.forceHandlerRepaint();
             wpd.graphicsWidget.updateZoomToImagePosn(lastPt.x, lastPt.y);
@@ -529,14 +542,21 @@ wpd.AdjustDataPointTool = (function() {
                     pointPx = selPoint.x,
                     pointPy = selPoint.y;
 
+                // rotate to current rotation
+                const currentRotation = wpd.graphicsWidget.getRotation();
+                let {
+                    x,
+                    y
+                } = wpd.graphicsWidget.getRotatedCoordinates(0, currentRotation, pointPx, pointPy);
+
                 if (wpd.keyCodes.isUp(ev.keyCode)) {
-                    pointPy = pointPy - stepSize;
+                    y = y - stepSize;
                 } else if (wpd.keyCodes.isDown(ev.keyCode)) {
-                    pointPy = pointPy + stepSize;
+                    y = y + stepSize;
                 } else if (wpd.keyCodes.isLeft(ev.keyCode)) {
-                    pointPx = pointPx - stepSize;
+                    x = x - stepSize;
                 } else if (wpd.keyCodes.isRight(ev.keyCode)) {
-                    pointPx = pointPx + stepSize;
+                    x = x + stepSize;
                 } else if (selIndexes.length === 1) {
                     // single selected point operations
                     if (wpd.keyCodes.isAlphabet(ev.keyCode, 'q')) {
@@ -545,12 +565,20 @@ wpd.AdjustDataPointTool = (function() {
                         selPoint = dataset.getPixel(selIndex);
                         pointPx = selPoint.x;
                         pointPy = selPoint.y;
+                        ({
+                            x,
+                            y
+                        } = wpd.graphicsWidget.getRotatedCoordinates(0, currentRotation, pointPx, pointPy));
                     } else if (wpd.keyCodes.isAlphabet(ev.keyCode, 'w')) {
                         dataset.selectNextPixel();
                         selIndex = dataset.getSelectedPixels()[0];
                         selPoint = dataset.getPixel(selIndex);
                         pointPx = selPoint.x;
                         pointPy = selPoint.y;
+                        ({
+                            x,
+                            y
+                        } = wpd.graphicsWidget.getRotatedCoordinates(0, currentRotation, pointPx, pointPy));
                     } else if (wpd.keyCodes.isAlphabet(ev.keyCode, 'e')) {
                         if (axes.dataPointsHaveLabels) {
                             selIndex = dataset.getSelectedPixels()[0];
@@ -568,6 +596,10 @@ wpd.AdjustDataPointTool = (function() {
                             selPoint = dataset.getPixel(selIndex);
                             pointPx = selPoint.x;
                             pointPy = selPoint.y;
+                            ({
+                                x,
+                                y
+                            } = wpd.graphicsWidget.getRotatedCoordinates(0, currentRotation, pointPx, pointPy));
                         }
                         wpd.graphicsWidget.resetData();
                         wpd.graphicsWidget.forceHandlerRepaint();
@@ -583,8 +615,14 @@ wpd.AdjustDataPointTool = (function() {
                     return;
                 }
 
-                dataset.setPixelAt(selIndex, pointPx, pointPy);
-                wpd.graphicsWidget.updateZoomToImagePosn(pointPx, pointPy);
+                // rotate back to original rotation
+                ({
+                    x,
+                    y
+                } = wpd.graphicsWidget.getRotatedCoordinates(currentRotation, 0, x, y));
+
+                dataset.setPixelAt(selIndex, x, y);
+                wpd.graphicsWidget.updateZoomToImagePosn(x, y);
             }.bind(this));
 
             wpd.graphicsWidget.forceHandlerRepaint();

--- a/app/javascript/widgets/graphicsWidget.js
+++ b/app/javascript/widgets/graphicsWidget.js
@@ -40,14 +40,16 @@ wpd.graphicsWidget = (function() {
 
         aspectRatio, displayAspectRatio,
 
-        originalImageData, scaledImage, zoomRatio, extendedCrosshair = false,
+        originalImageData, zoomRatio, extendedCrosshair = false,
         hoverTimer,
 
         activeTool, repaintHandler,
 
         isCanvasInFocus = false,
 
-        firstLoad = true;
+        firstLoad = true,
+
+        rotation = 0;
 
     function posn(ev) { // get screen pixel from event
         let mainCanvasPosition = $mainCanvas.getBoundingClientRect();
@@ -59,10 +61,20 @@ wpd.graphicsWidget = (function() {
 
     // get image pixel when screen pixel is provided
     function imagePx(screenX, screenY) {
-        return {
-            x: screenX / zoomRatio,
-            y: screenY / zoomRatio
-        };
+        const imageX = screenX / zoomRatio;
+        const imageY = screenY / zoomRatio;
+
+        if (rotation === 0) {
+            // this function is often called frequently
+            // do not do extra work if canvases have not been rotated
+            return {
+                x: imageX,
+                y: imageY
+            };
+        } else {
+            // rotate given x and y after dividing by zoom ratio
+            return getRotatedCoordinates(rotation, 0, imageX, imageY);
+        }
     }
 
     // get screen pixel when image pixel is provided
@@ -104,7 +116,6 @@ wpd.graphicsWidget = (function() {
     }
 
     function resize(cwidth, cheight) {
-
         cwidth = parseInt(cwidth, 10);
         cheight = parseInt(cheight, 10);
 
@@ -127,8 +138,6 @@ wpd.graphicsWidget = (function() {
 
         width = cwidth;
         height = cheight;
-
-        drawImage();
     }
 
     function resetAllLayers() {
@@ -144,13 +153,13 @@ wpd.graphicsWidget = (function() {
         $oriDataCanvas.width = $oriDataCanvas.width;
     }
 
-    function drawImage() {
+    function drawImage(dx, dy) {
         if (originalImageData == null)
             return;
 
         mainCtx.fillStyle = "rgb(255, 255, 255)";
-        mainCtx.fillRect(0, 0, width, height);
-        mainCtx.drawImage($oriImageCanvas, 0, 0, width, height);
+        mainCtx.fillRect(0, 0, dx, dy);
+        mainCtx.drawImage($oriImageCanvas, 0, 0, dx, dy);
 
         if (repaintHandler != null && repaintHandler.onRedraw != undefined) {
             repaintHandler.onRedraw();
@@ -192,6 +201,106 @@ wpd.graphicsWidget = (function() {
         dataCtx.drawImage($oriDataCanvas, 0, 0, width, height);
     }
 
+    function getRotationMatrix(degrees, dx, dy) {
+        // determine translation (moves origin)
+        let xTranslation, yTranslation;
+        switch (degrees) {
+            case 90:
+                xTranslation = dy ?? 0;
+                yTranslation = 0;
+                break;
+            case 180:
+                xTranslation = dx ?? 0;
+                yTranslation = dy ?? 0;
+                break;
+            case 270:
+                xTranslation = 0;
+                yTranslation = dx ?? 0;
+                break;
+            default:
+                xTranslation = 0;
+                yTranslation = 0;
+                break;
+        }
+
+        // convert degrees to radians
+        const radians = degrees * Math.PI / 180;
+
+        // define transformation matrix [a, b, c, d, e, f]
+        // matrix format:
+        //   a c e 0
+        //   b d f 0
+        //   0 0 1 0
+        //   0 0 0 1
+        return new DOMMatrix([
+            Math.cos(radians),
+            Math.sin(radians),
+            -Math.sin(radians),
+            Math.cos(radians),
+            xTranslation,
+            yTranslation,
+        ]);
+    };
+
+    function rotateClockwise() {
+        rotateAndResize(90);
+    }
+
+    function rotateCounterClockwise() {
+        rotateAndResize(-90);
+    }
+
+    function rotateAndResize(deltaDegrees = 0, newWidth = null, newHeight = null) {
+        // do nothing if delta degrees value is not a multiple of 90
+        if (Math.abs(deltaDegrees) % 90 !== 0) {
+            return;
+        }
+
+        // use provided width and height, if available
+        // otherwise, use current zoomed width and height values
+        const displayWidth = newWidth ?? (originalWidth * zoomRatio);
+        const displayHeight = newHeight ?? (originalHeight * zoomRatio);
+
+        // add delta degrees to rotation
+        // if rotation is 0 start at 360
+        // modulo to make sure it is 0 <= d < 360
+        rotation = ((rotation || 360) + deltaDegrees) % 360;
+
+        // determine if it is necessary to swap canvas width and height
+        const dimensions = rotation % 180 === 0 ?
+            [displayWidth, displayHeight] :
+            [displayHeight, displayWidth];
+
+        // setting size clears canvases, update the size of the canvases before transforming
+        resize(...dimensions);
+
+        // get transformation matrix and set transform on canvas context
+        const matrix = getRotationMatrix(rotation, displayWidth, displayHeight);
+        mainCtx.setTransform(matrix);
+        dataCtx.setTransform(matrix);
+        drawCtx.setTransform(matrix);
+        hoverCtx.setTransform(matrix);
+        topCtx.setTransform(matrix);
+
+        // draw the image with the rotation independent dimensions
+        drawImage(displayWidth, displayHeight);
+
+        // fire rotation event if image has been rotated
+        if (deltaDegrees !== 0) {
+            wpd.events.dispatch("wpd.image.rotate", {
+                rotation: rotation
+            });
+        }
+    }
+
+    function getRotation() {
+        return rotation;
+    }
+
+    function setRotation(degrees) {
+        rotation = degrees;
+    }
+
     function zoomIn() {
         setZoomRatio(zoomRatio * 1.2);
     }
@@ -206,10 +315,10 @@ wpd.graphicsWidget = (function() {
 
         if (newAspectRatio > aspectRatio) {
             zoomRatio = viewportSize.height / (originalHeight * 1.0);
-            resize(viewportSize.height * aspectRatio, viewportSize.height);
+            rotateAndResize(0, viewportSize.height * aspectRatio, viewportSize.height);
         } else {
             zoomRatio = viewportSize.width / (originalWidth * 1.0);
-            resize(viewportSize.width, viewportSize.width / aspectRatio);
+            rotateAndResize(0, viewportSize.width, viewportSize.width / aspectRatio);
         }
     }
 
@@ -219,7 +328,7 @@ wpd.graphicsWidget = (function() {
 
     function setZoomRatio(zratio) {
         zoomRatio = zratio;
-        resize(originalWidth * zoomRatio, originalHeight * zoomRatio);
+        rotateAndResize(0, originalWidth * zoomRatio, originalHeight * zoomRatio);
     }
 
     function getZoomRatio() {
@@ -229,6 +338,9 @@ wpd.graphicsWidget = (function() {
     function resetData() {
         $oriDataCanvas.width = $oriDataCanvas.width;
         $dataCanvas.width = $dataCanvas.width;
+
+        // re-rotate canvases
+        rotateAndResize();
     }
 
     function resetHover() {
@@ -272,6 +384,61 @@ wpd.graphicsWidget = (function() {
 
         setZoomImage(imagePos.x, imagePos.y);
         wpd.zoomView.setCoords(imagePos.x, imagePos.y);
+    }
+
+    function getRotatedCoordinates(sourceDegrees, targetDegrees, x, y) {
+        // get the delta degrees
+        const deltaDegrees = targetDegrees - sourceDegrees;
+
+        // short-circuit
+        // return original x and y if delta degrees is not a multiple of 90
+        if (Math.abs(deltaDegrees) % 90 !== 0) {
+            return {
+                x: x,
+                y: y
+            };
+        }
+
+        // determine source rotation image dimensions
+        const dimensions = sourceDegrees % 180 === 0 ?
+            {
+                x: originalWidth,
+                y: originalHeight
+            } :
+            {
+                x: originalHeight,
+                y: originalWidth
+            };
+
+        let rotatedX, rotatedY;
+        switch (deltaDegrees) {
+            case 90:
+            case -270:
+                rotatedX = dimensions.y - y;
+                rotatedY = x;
+                break;
+            case 180:
+            case -180:
+                rotatedX = dimensions.x - x;
+                rotatedY = dimensions.y - y;
+                break;
+            case 270:
+            case -90:
+                rotatedX = y;
+                rotatedY = dimensions.x - x;
+                break;
+            case 360:
+            case 0:
+            default:
+                rotatedX = x;
+                rotatedY = y;
+                break;
+        }
+
+        return {
+            x: rotatedX,
+            y: rotatedY
+        };
     }
 
     function setZoomImage(ix, iy) {
@@ -334,7 +501,7 @@ wpd.graphicsWidget = (function() {
         ycorr = zratio * (parseInt(iymin, 10) - iymin);
 
         wpd.zoomView.setZoomImage(idata, parseInt(zxmin + xcorr, 10), parseInt(zymin + ycorr, 10),
-            parseInt(zxmax - zxmin, 10), parseInt(zymax - zymin, 10));
+            parseInt(zxmax - zxmin, 10), parseInt(zymax - zymin, 10), getRotationMatrix(rotation, zxmax, zymax));
     }
 
     function updateZoomOnEvent(ev) {
@@ -451,7 +618,7 @@ wpd.graphicsWidget = (function() {
         }, false);
     }
 
-    function loadImage(originalImage) {
+    function loadImage(originalImage, savedRotation) {
         if ($mainCanvas == null) {
             init();
         }
@@ -466,6 +633,7 @@ wpd.graphicsWidget = (function() {
         $oriDataCanvas.height = originalHeight;
         oriImageCtx.drawImage(originalImage, 0, 0, originalWidth, originalHeight);
         originalImageData = oriImageCtx.getImageData(0, 0, originalWidth, originalHeight);
+        setRotation(savedRotation);
         resetAllLayers();
         zoomFit();
         return originalImageData;
@@ -670,6 +838,14 @@ wpd.graphicsWidget = (function() {
         toggleExtendedCrosshairBtn: toggleExtendedCrosshairBtn,
         setZoomRatio: setZoomRatio,
         getZoomRatio: getZoomRatio,
+
+        rotateClockwise: rotateClockwise,
+        rotateCounterClockwise: rotateCounterClockwise,
+        rotateAndResize: rotateAndResize,
+        getRotation: getRotation,
+        setRotation: setRotation,
+        getRotationMatrix: getRotationMatrix,
+        getRotatedCoordinates: getRotatedCoordinates,
 
         runImageOp: runImageOp,
 

--- a/app/javascript/widgets/graphicsWidget.js
+++ b/app/javascript/widgets/graphicsWidget.js
@@ -267,9 +267,7 @@ wpd.graphicsWidget = (function() {
         rotation = ((rotation || 360) + deltaDegrees) % 360;
 
         // determine if it is necessary to swap canvas width and height
-        const dimensions = rotation % 180 === 0 ?
-            [displayWidth, displayHeight] :
-            [displayHeight, displayWidth];
+        const dimensions = rotation % 180 === 0 ? [displayWidth, displayHeight] : [displayHeight, displayWidth];
 
         // setting size clears canvases, update the size of the canvases before transforming
         resize(...dimensions);
@@ -400,15 +398,13 @@ wpd.graphicsWidget = (function() {
         }
 
         // determine source rotation image dimensions
-        const dimensions = sourceDegrees % 180 === 0 ?
-            {
-                x: originalWidth,
-                y: originalHeight
-            } :
-            {
-                x: originalHeight,
-                y: originalWidth
-            };
+        const dimensions = sourceDegrees % 180 === 0 ? {
+            x: originalWidth,
+            y: originalHeight
+        } : {
+            x: originalHeight,
+            y: originalWidth
+        };
 
         let rotatedX, rotatedY;
         switch (deltaDegrees) {

--- a/app/javascript/widgets/zoom.js
+++ b/app/javascript/widgets/zoom.js
@@ -81,11 +81,13 @@ wpd.zoomView = (function() {
         };
     }
 
-    function setZoomImage(imgData, x0, y0, zwidth, zheight) {
+    function setZoomImage(imgData, x0, y0, zwidth, zheight, matrix) {
         tempCanvas.width = zwidth / zoomRatio;
         tempCanvas.height = zheight / zoomRatio;
         tctx.putImageData(imgData, 0, 0);
         zCanvas.width = zCanvas.width;
+        // rotate zoom canvas after reset (setting width resets)
+        zctx.setTransform(matrix);
         zctx.drawImage(tempCanvas, x0, y0, zwidth, zheight);
     }
 

--- a/app/karma.conf.js
+++ b/app/karma.conf.js
@@ -1,0 +1,109 @@
+// Karma configuration
+// Generated on Fri Apr 29 2022 09:54:51 GMT-0400 (Eastern Daylight Time)
+
+module.exports = function(config) {
+    config.set({
+
+        // base path that will be used to resolve all patterns (eg. files, exclude)
+        basePath: "",
+
+
+        // frameworks to use
+        // available frameworks: https://www.npmjs.com/search?q=keywords:karma-adapter
+        frameworks: ["qunit", "sinon"],
+
+        // plugins to use
+        plugins: [
+            "karma-*",
+        ],
+
+
+        // list of files / patterns to load in the browser
+        files: [
+            "javascript/**/*.js",   // wpd javascript library
+            "tests/**/*_tests.js",  // qunit tests
+            "tests/testhelpers.js", // test helper
+            {
+                pattern: "start.png",
+                watched: false,
+                included: false,
+            },
+            {
+                pattern: "tests/files/*.json",
+                watched: false,
+                included: false,
+            }
+        ],
+
+
+        // proxies
+        proxies: {
+            "/start.png": "/base/start.png",
+            "/files/": "/base/tests/files/",
+        },
+
+
+        // list of files / patterns to exclude
+        exclude: [
+            "javascript/main.js", // main wpd entry point
+        ],
+
+
+        // preprocess matching files before serving them to the browser
+        // available preprocessors: https://www.npmjs.com/search?q=keywords:karma-preprocessor
+        preprocessors: {
+        },
+
+
+        // test results reporter to use
+        // possible values: "dots", "progress"
+        // available reporters: https://www.npmjs.com/search?q=keywords:karma-reporter
+        reporters: ["progress"],
+
+
+        // web server port
+        port: 9876,
+
+
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
+
+
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
+
+
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
+
+
+        // start these browsers
+        // available browser launchers: https://www.npmjs.com/search?q=keywords:karma-launcher
+        browsers: [
+            // "Chrome",
+            "ChromeHeadless",
+            // "Edge",
+            // "Firefox",
+        ],
+
+
+        // Continuous Integration mode
+        // if true, Karma captures browsers, runs the tests and exits
+        singleRun: true,
+
+        // Concurrency level
+        // how many browser instances should be started simultaneously
+        concurrency: Infinity,
+
+        // client configuration
+        client: {
+            clearContext: false,
+            qunit: {
+                showUI: true,
+                testTimeout: 5000,
+            },
+            useIframe: false,
+        },
+    })
+}

--- a/app/locale/de_DE/LC_MESSAGES/messages.po
+++ b/app/locale/de_DE/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 11:21-0400\n"
+"POT-Creation-Date: 2022-04-28 14:14-0400\n"
 "PO-Revision-Date: 2019-02-24 00:40-0800\n"
 "Last-Translator: \n"
 "Language: de_DE\n"
@@ -32,7 +32,7 @@ msgid ""
 "Firefox, Safari or Microsoft Edge installed."
 msgstr ""
 
-#: templates/_base.html:76
+#: templates/_base.html:78
 msgid "Fit"
 msgstr ""
 
@@ -1088,7 +1088,9 @@ msgid "Clear data points?"
 msgstr ""
 
 #: templates/_strings.html:13
-msgid "This will delete all data points from this dataset"
+msgid ""
+"This will delete all data points and point group definitions from this "
+"dataset"
 msgstr ""
 
 #: templates/_strings.html:15
@@ -2342,7 +2344,7 @@ msgstr ""
 #~ msgstr "Datenpunkte löschen?"
 
 #~ msgid "This will delete all data points from this dataset"
-#~ msgstr "Dadurch werden alle Datenpunkte aus diesem Datensatz gelöscht."
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Your browser does not support webcam "

--- a/app/locale/en_US/LC_MESSAGES/messages.po
+++ b/app/locale/en_US/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 11:21-0400\n"
+"POT-Creation-Date: 2022-04-28 14:14-0400\n"
 "PO-Revision-Date: 2016-12-12 23:09-0600\n"
 "Last-Translator: \n"
 "Language: en_US\n"
@@ -32,7 +32,7 @@ msgid ""
 "Firefox, Safari or Microsoft Edge installed."
 msgstr ""
 
-#: templates/_base.html:76
+#: templates/_base.html:78
 msgid "Fit"
 msgstr ""
 
@@ -1088,7 +1088,9 @@ msgid "Clear data points?"
 msgstr ""
 
 #: templates/_strings.html:13
-msgid "This will delete all data points from this dataset"
+msgid ""
+"This will delete all data points and point group definitions from this "
+"dataset"
 msgstr ""
 
 #: templates/_strings.html:15

--- a/app/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/app/locale/fr_FR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 11:21-0400\n"
+"POT-Creation-Date: 2022-04-28 14:14-0400\n"
 "PO-Revision-Date: 2017-11-01 23:56-0500\n"
 "Last-Translator: \n"
 "Language: fr_FR\n"
@@ -32,7 +32,7 @@ msgid ""
 "Firefox, Safari or Microsoft Edge installed."
 msgstr ""
 
-#: templates/_base.html:76
+#: templates/_base.html:78
 msgid "Fit"
 msgstr ""
 
@@ -1088,7 +1088,9 @@ msgid "Clear data points?"
 msgstr ""
 
 #: templates/_strings.html:13
-msgid "This will delete all data points from this dataset"
+msgid ""
+"This will delete all data points and point group definitions from this "
+"dataset"
 msgstr ""
 
 #: templates/_strings.html:15
@@ -2343,7 +2345,7 @@ msgstr ""
 #~ msgstr "Effacer les points de données?"
 
 #~ msgid "This will delete all data points from this dataset"
-#~ msgstr "Ceci va supprimer tous les points de données de ce dataset"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Your browser does not support webcam "

--- a/app/locale/ja/LC_MESSAGES/messages.po
+++ b/app/locale/ja/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 11:21-0400\n"
+"POT-Creation-Date: 2022-04-28 14:14-0400\n"
 "PO-Revision-Date: 2016-12-18 10:38-0600\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -32,7 +32,7 @@ msgid ""
 "Firefox, Safari or Microsoft Edge installed."
 msgstr ""
 
-#: templates/_base.html:76
+#: templates/_base.html:78
 msgid "Fit"
 msgstr ""
 
@@ -1088,7 +1088,9 @@ msgid "Clear data points?"
 msgstr ""
 
 #: templates/_strings.html:13
-msgid "This will delete all data points from this dataset"
+msgid ""
+"This will delete all data points and point group definitions from this "
+"dataset"
 msgstr ""
 
 #: templates/_strings.html:15

--- a/app/locale/messages.pot
+++ b/app/locale/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 11:21-0400\n"
+"POT-Creation-Date: 2022-04-28 14:14-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,7 +31,7 @@ msgid ""
 "Firefox, Safari or Microsoft Edge installed."
 msgstr ""
 
-#: templates/_base.html:76
+#: templates/_base.html:78
 msgid "Fit"
 msgstr ""
 
@@ -1087,7 +1087,9 @@ msgid "Clear data points?"
 msgstr ""
 
 #: templates/_strings.html:13
-msgid "This will delete all data points from this dataset"
+msgid ""
+"This will delete all data points and point group definitions from this "
+"dataset"
 msgstr ""
 
 #: templates/_strings.html:15

--- a/app/locale/ru/LC_MESSAGES/messages.po
+++ b/app/locale/ru/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 11:21-0400\n"
+"POT-Creation-Date: 2022-04-28 14:14-0400\n"
 "PO-Revision-Date: 2016-12-18 10:38-0600\n"
 "Last-Translator: \n"
 "Language: ru\n"
@@ -33,7 +33,7 @@ msgid ""
 "Firefox, Safari or Microsoft Edge installed."
 msgstr ""
 
-#: templates/_base.html:76
+#: templates/_base.html:78
 msgid "Fit"
 msgstr ""
 
@@ -1089,7 +1089,9 @@ msgid "Clear data points?"
 msgstr ""
 
 #: templates/_strings.html:13
-msgid "This will delete all data points from this dataset"
+msgid ""
+"This will delete all data points and point group definitions from this "
+"dataset"
 msgstr ""
 
 #: templates/_strings.html:15

--- a/app/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/app/locale/zh_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  WebPlotDigitizer\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-29 11:21-0400\n"
+"POT-Creation-Date: 2022-04-28 14:14-0400\n"
 "PO-Revision-Date: 2018-02-21 00:47-0600\n"
 "Last-Translator: RGXGR <rgxgr@outlook.com>\n"
 "Language: zh_Hans_CN\n"
@@ -32,7 +32,7 @@ msgid ""
 "Firefox, Safari or Microsoft Edge installed."
 msgstr ""
 
-#: templates/_base.html:76
+#: templates/_base.html:78
 msgid "Fit"
 msgstr ""
 
@@ -1088,7 +1088,9 @@ msgid "Clear data points?"
 msgstr ""
 
 #: templates/_strings.html:13
-msgid "This will delete all data points from this dataset"
+msgid ""
+"This will delete all data points and point group definitions from this "
+"dataset"
 msgstr ""
 
 #: templates/_strings.html:15
@@ -2278,7 +2280,7 @@ msgstr ""
 #~ msgstr "清除数据点？"
 
 #~ msgid "This will delete all data points from this dataset"
-#~ msgstr "您将清除当前数据集的所有数据点"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Your browser does not support webcam "

--- a/app/package.json
+++ b/app/package.json
@@ -7,11 +7,20 @@
     "scripts": {
         "prebuild": "./build.sh",
         "build": "uglifyjs combined.js -cm -o wpd.min.js",
-        "format": "./format.sh"
+        "format": "./format.sh",
+        "test": "./node_modules/karma/bin/karma start"
     },
     "devDependencies": {
-        "uglify-js": ">=3.14.2",
-        "js-beautify": ">=1.14.0"
+        "js-beautify": ">=1.14.0",
+        "karma": ">=6.3.19",
+        "karma-chrome-launcher": ">=3.1.1",
+        "karma-edge-launcher": ">=0.4.2",
+        "karma-firefox-launcher": ">=2.1.2",
+        "karma-qunit": ">=4.1.2",
+        "karma-sinon": ">=1.0.5",
+        "qunit": ">=2.19.0",
+        "sinon": ">=13.0.2",
+        "uglify-js": ">=3.14.2"
     },
     "dependencies": {
         "pdfjs-dist": "~2.9.359",

--- a/app/templates/_base.html
+++ b/app/templates/_base.html
@@ -69,7 +69,9 @@
                     </div>
                 </div>
 
-                <div style="display:inline-block; position: absolute; top: 5px; right: 290px;">
+                <div style="display: inline-flex; justify-content: space-between; width: 200px; position: absolute; top: 9px; right: 290px;">
+                    <button type="button" title="Rotate 90° counter-clockwise" onclick="wpd.graphicsWidget.rotateCounterClockwise();" style="border:none; width:20px; font-size:16px; display:inline-flex; align-items:self-end; justify-content:center;">↺</button>
+                    <button type="button" title="Rotate 90° clockwise" onclick="wpd.graphicsWidget.rotateClockwise();" style="border:none; width:20px; font-size:16px; display:inline-flex; align-items:self-end; justify-content:center;">↻</button>
                     <button type="button" title="Zoom in" onclick="wpd.graphicsWidget.zoomIn();" style="border:none; width:20px;">+</button>
                     <button type="button" title="Zoom out" onclick="wpd.graphicsWidget.zoomOut();" style="border:none; width:20px;">-</button>
                     <button type="button" title="View actual size" onclick="wpd.graphicsWidget.zoom100perc();" style="border:none;">100%</button>

--- a/app/tests/circular_chart_recorder_tests.js
+++ b/app/tests/circular_chart_recorder_tests.js
@@ -2,10 +2,22 @@ QUnit.module("Circular chart recorder tests");
 QUnit.test("Calibration", function(assert) {
 
     let calib = new wpd.Calibration(2);
-    // add 5 calibration points
 
-    let circAxes = wpd.CircularChartRecorder();
-    circAxes.calibrate(calib);
+    // add 5 calibration points
+    calib.addPoint(1, 1, 0, 0);
+    calib.addPoint(1.6, 1.8, 0, 0);
+    calib.addPoint(1.707, 1.707, 0, 0);
+    calib.addPoint(1, 2, 0, 0);
+    calib.addPoint(0, 1, 0, 0);
+
+    calib.setDataAt(0, "0", "0");
+    calib.setDataAt(1, "0", 0);
+    calib.setDataAt(2, "0", "1");
+    calib.setDataAt(3, 0, "1");
+    calib.setDataAt(4, 0, "1");
+
+    let circAxes = new wpd.CircularChartRecorderAxes();
+    circAxes.calibrate(calib, "0");
 
     assert.equal(1, 1, "dummy");
 });

--- a/app/tests/file_manager_tests.js
+++ b/app/tests/file_manager_tests.js
@@ -252,6 +252,9 @@ QUnit.test("Get metadata for JSON", (assert) => {
             getPageLabelMap: sinon.stub().returns({
                 1: "hello",
                 2: "goodbye"
+            }),
+            getRotationMap: sinon.stub().returns({
+                2: 180
             })
         }
     };
@@ -274,6 +277,11 @@ QUnit.test("Get metadata for JSON", (assert) => {
                 0: {
                     1: "hello",
                     2: "goodbye"
+                }
+            },
+            rotation: {
+                0: {
+                    2: 180
                 }
             }
         }
@@ -328,6 +336,9 @@ QUnit.test("Get metadata for JSON", (assert) => {
             }),
             getPageLabelMap: sinon.stub().returns({
                 1: "hello"
+            }),
+            getRotationMap: sinon.stub().returns({
+                2: 90
             })
         },
         1: {
@@ -342,6 +353,9 @@ QUnit.test("Get metadata for JSON", (assert) => {
             }),
             getPageLabelMap: sinon.stub().returns({
                 1: "goodbye"
+            }),
+            getRotationMap: sinon.stub().returns({
+                1: 270
             })
         }
     };
@@ -396,6 +410,14 @@ QUnit.test("Get metadata for JSON", (assert) => {
                 1: {
                     1: "goodbye"
                 }
+            },
+            rotation: {
+                0: {
+                    2: 90
+                },
+                1: {
+                    1: 270
+                }
             }
         }
     };
@@ -418,6 +440,9 @@ QUnit.test("Get metadata for JSON", (assert) => {
             }),
             getPageLabelMap: sinon.stub().returns({
                 1: "hello"
+            }),
+            getRotationMap: sinon.stub().returns({
+                1: 180
             })
         }
     };
@@ -466,6 +491,11 @@ QUnit.test("Get metadata for JSON", (assert) => {
             pageLabel: {
                 0: {
                     1: "hello"
+                }
+            },
+            rotation: {
+                0: {
+                    1: 180
                 }
             }
         }

--- a/app/tests/graphics_widget_tests.js
+++ b/app/tests/graphics_widget_tests.js
@@ -1,0 +1,212 @@
+QUnit.module(
+    "Graphics widget tests", {
+        beforeEach: () => {
+            // create canvas elements
+            const canvasDiv = document.createElement("div");
+            canvasDiv.setAttribute("id", "canvasDiv");
+            document.body.appendChild(canvasDiv);
+
+            canvasIDs.forEach((id, index) => {
+                canvasDiv.insertAdjacentHTML(
+                    "beforeend",
+                    `<canvas id="${id}" class="canvasLayers" style="z-index:${index + 1};"></canvas>`
+                );
+            });
+
+            // default rotation 0
+            wpd.graphicsWidget.setRotation(0);
+
+            // stub functions
+            sinon
+                .stub(wpd.layoutManager, "getGraphicsViewportSize")
+                .returns({
+                    width: 800,
+                    height: 600
+                });
+        },
+        afterEach: () => {
+            // remove canvas elements
+            canvasIDs.forEach((id) => {
+                document.getElementById(id).remove();
+            });
+
+            document.getElementById("canvasDiv").remove();
+
+            // restore mocks and fakes
+            sinon.restore();
+        }
+    }
+);
+
+// consts are also hoisted, defined here for organizational reasons
+const canvasIDs = [
+    "mainCanvas",
+    "dataCanvas",
+    "drawCanvas",
+    "hoverCanvas",
+    "topCanvas",
+    "zoomCanvas",
+    "zoomCrossHair"
+];
+
+// define image for use with testing
+const image = new Image();
+image.src = "../start.png";
+
+QUnit.test("Load image", (assert) => {
+    // load image
+    const result = wpd.graphicsWidget.loadImage(image);
+
+    // page info elements hide check
+    assert.ok(result, "Image loaded");
+});
+
+QUnit.test("Get image pixel coordinates", (assert) => {
+    // load image
+    wpd.graphicsWidget.loadImage(image);
+
+    const pixel = [0, 0];
+
+    // without rotation
+    const results0 = wpd.graphicsWidget.imagePx(...pixel);
+    const expected0 = {
+        x: 0,
+        y: 0
+    };
+    assert.deepEqual(results0, expected0, "Without rotation");
+
+    // with rotation
+    wpd.graphicsWidget.setRotation(90);
+    const results1 = wpd.graphicsWidget.imagePx(...pixel);
+    const expected1 = {
+        x: 0,
+        y: 600
+    };
+    assert.deepEqual(results1, expected1, "With rotation");
+});
+
+QUnit.test("Get rotation matrix for canvas", (assert) => {
+    // load image
+    wpd.graphicsWidget.loadImage(image);
+
+    const degreesToRadians = (d) => d * Math.PI / 180;
+
+    // 0° rotation
+    const degrees0 = 0;
+    const radians0 = degreesToRadians(degrees0);
+    const results0 = wpd.graphicsWidget.getRotationMatrix(degrees0, 800, 600);
+    const expected0 = new DOMMatrix([
+        Math.cos(radians0),
+        Math.sin(radians0),
+        -Math.sin(radians0),
+        Math.cos(radians0),
+        0,
+        0,
+    ]);
+    assert.deepEqual(results0, expected0, "0° rotation");
+
+    // 90° rotation
+    const degrees1 = 90;
+    const radians1 = degreesToRadians(degrees1);
+    const results1 = wpd.graphicsWidget.getRotationMatrix(degrees1, 600, 800);
+    const expected1 = new DOMMatrix([
+        Math.cos(radians1),
+        Math.sin(radians1),
+        -Math.sin(radians1),
+        Math.cos(radians1),
+        800,
+        0,
+    ]);
+    assert.deepEqual(results1, expected1, "90° rotation");
+
+    // 180° rotation
+    const degrees2 = 180;
+    const radians2 = degreesToRadians(degrees2);
+    const results2 = wpd.graphicsWidget.getRotationMatrix(degrees2, 800, 600);
+    const expected2 = new DOMMatrix([
+        Math.cos(radians2),
+        Math.sin(radians2),
+        -Math.sin(radians2),
+        Math.cos(radians2),
+        800,
+        600,
+    ]);
+    assert.deepEqual(results2, expected2, "180° rotation");
+
+    // 270° rotation
+    const degrees3 = 270;
+    const radians3 = degreesToRadians(degrees3);
+    const results3 = wpd.graphicsWidget.getRotationMatrix(degrees3, 600, 800);
+    const expected3 = new DOMMatrix([
+        Math.cos(radians3),
+        Math.sin(radians3),
+        -Math.sin(radians3),
+        Math.cos(radians3),
+        0,
+        600,
+    ]);
+    assert.deepEqual(results3, expected3, "270° rotation");
+});
+
+QUnit.test("Get rotated coordinates", (assert) => {
+    // load image
+    wpd.graphicsWidget.loadImage(image);
+
+    const pixel = [10, 20];
+
+    // 0° rotation
+    const results0 = wpd.graphicsWidget.getRotatedCoordinates(0, 0, ...pixel);
+    const expected0 = {
+        x: 10,
+        y: 20
+    };
+    assert.deepEqual(results0, expected0, "0° rotation");
+
+    // 90° rotation
+    const results1 = wpd.graphicsWidget.getRotatedCoordinates(0, 90, ...pixel);
+    const expected1 = {
+        x: 580,
+        y: 10
+    };
+    assert.deepEqual(results1, expected1, "90° rotation");
+
+    // 180° rotation
+    const results2 = wpd.graphicsWidget.getRotatedCoordinates(0, 180, ...pixel);
+    const expected2 = {
+        x: 790,
+        y: 580
+    };
+    assert.deepEqual(results2, expected2, "180° rotation");
+
+    // 270° rotation
+    const results3 = wpd.graphicsWidget.getRotatedCoordinates(0, 270, ...pixel);
+    const expected3 = {
+        x: 20,
+        y: 790
+    };
+    assert.deepEqual(results3, expected3, "270° rotation");
+
+    // -90° rotation
+    const results4 = wpd.graphicsWidget.getRotatedCoordinates(180, 90, ...pixel);
+    const expected4 = {
+        x: 20,
+        y: 790
+    };
+    assert.deepEqual(results4, expected4, "-90° rotation");
+
+    // -180° rotation
+    const results5 = wpd.graphicsWidget.getRotatedCoordinates(270, 90, ...pixel);
+    const expected5 = {
+        x: 590,
+        y: 780
+    };
+    assert.deepEqual(results5, expected5, "-180° rotation");
+
+    // with counter-clockwise rotation
+    const results6 = wpd.graphicsWidget.getRotatedCoordinates(0, 90, ...pixel);
+    const expected6 = {
+        x: 580,
+        y: 10
+    };
+    assert.deepEqual(results6, expected6, "270° rotation");
+});

--- a/app/tests/index.html
+++ b/app/tests/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>WPD Tests</title>
-  <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.12.0.css">
+  <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 
   <!-- WPD -->
   <script src="../javascript/controllers/appData.js"></script>
@@ -82,9 +82,9 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/sinon.js/9.2.1/sinon.min.js"></script>
-  <script src="https://code.jquery.com/qunit/qunit-2.12.0.js"></script>
-  <script src="../thirdparty/pdfjs/build/pdf.js"></script>
+  <script src="../node_modules/sinon/pkg/sinon.js"></script>
+  <script src="../node_modules/qunit/qunit/qunit.js"></script>
+  <script src="../node_modules/pdfjs-dist/build/pdf.js"></script>
   <script src="testhelpers.js"></script>
   <script src="app_data_tests.js"></script>
   <script src="axes_tests.js"></script>
@@ -96,6 +96,7 @@
   <script src="date_tests.js"></script>
   <script src="events_tests.js"></script>
   <script src="file_manager_tests.js"></script>
+  <script src="graphics_widget_tests.js"></script>
   <script src="math_functions_tests.js"></script>
   <script src="manual_detection_tools_tests.js"></script>
   <script src="point_groups_tests.js"></script>

--- a/app/tests/math_functions_tests.js
+++ b/app/tests/math_functions_tests.js
@@ -24,7 +24,6 @@ QUnit.test("getCircleFrom3Pts", function(assert) {
         "radius": 417.59805330481277
     };
     let circ2 = wpd.getCircleFrom3Pts(pts2);
-    console.log(circ2);
     assert.equal(Math.abs(circ2.radius - expectedRes2.radius) < 1e-10, true, "radius check2");
     assert.equal(Math.abs(circ2.x0 - expectedRes2.x0) < 1e-10, true, "x0 check2");
     assert.equal(Math.abs(circ2.y0 - expectedRes2.y0) < 1e-10, true, "y0 check2");

--- a/script_examples/README.md
+++ b/script_examples/README.md
@@ -149,3 +149,10 @@ An event system is available to attach listeners to various actions taken in Web
         - `axes`: `Axes` - Axes selected data point belongs to
         - `dataset`: `Dataset` - Data set selected data point belongs to
         - `indexes`: `Array` - Array containing indexes of selected data points in data set (for use with `Dataset.prototype.getPixel`)
+
+**`wpd.image.rotate`**
+> Fires when the image has been rotated
+
+- Payload:
+    - `Object`
+        - `rotation`: `Integer` - New rotation of image in degrees


### PR DESCRIPTION
Hello @ankitrohatgi, hope you are well!

I have two main updates in this PR:
- Added image rotation 
- Added ability to run unit tests from the command-line

Let me know your thoughts, happy to make additional changes.

-----

### Image rotation

Two new buttons have been added next to the zoom controls in the top toolbar - one for rotating 90° counter-clockwise, one for rotating 90° clockwise; as seen here:

![image](https://user-images.githubusercontent.com/633897/166003476-870d19e1-3e41-4c27-8ad9-97cda2af3e0b.png)

@billdenney and I thought this would compliment the existing set of image manipulation features well.

This rotation is achieved by rotating the appropriate canvases with 4 pre-defined transformation matrices. This can be updated to allow rotation to degrees that are not a multiple of 90°, but currently only multiples of 90° are supported.

Some notable points:
- Axis calibration, data, and measurement points captured on a rotated image are stored as if they were not rotated
- Keyboard adjustment of axis calibration, data, and measurement points work in the expected orientation
- Image rotations and zoom levels work together
- Zoomed image (top-right box) have been updated to work with rotations
- Image cropping (including undo and redo actions) has been updated to work with rotations
- Rotations are saved for PDFs by page
- Rotations are loaded for PDFs

Known short-comings:
- Rotations are currently not stored for standalone images
- Point labels are currently not rotated, this will require some additional code to rotate the canvas and draw the label in the correct location

### Running unit tests from the command-line

While I was adding unit tests for image rotation, I thought it would be nice to be able to run the unit tests via the command-line. This would enable git pre-commit/pre-push hooks to run unit tests down the road as well. (And perhaps along with code formatting.)

I installed [Karma](https://karma-runner.github.io/) as a dev dependency. You've probably hear of it; it's a test runner that can spin up browsers, watch for changes, and run tests in them.

I configured Karma to run tests and exit instead of watching for changes, but that can be changed with a few command-line options. By default, I'm having it run on Headless Chrome. Launchers for Chrome, Firefox, and Edge are also installed (these are not headless). I added usage details at the updated [DEVELOPER_GUIDELINES.md](https://github.com/ewchow/WebPlotDigitizer/blob/feature/add-image-rotation/DEVELOPER_GUIDELINES.md#unit-tests).

Karma can also run tests on Electron, but required the `electron` package to be installed in `app` as well. I didn't want to duplicate a somewhat large package, so I did not move forward with it.

I also added a convenience shortcut to `package.json` so unit tests can now be run in the command-line via `npm test` 🙂  
