### PR TITLE
feat: Automatically select new dataset upon creation

### DIFF
--- a/javascript/controllers/datasetManagement.js
+++ b/javascript/controllers/datasetManagement.js
@@ -146,11 +146,15 @@ wpd.dataSeriesManagement = (function() {
             let idx = getDatasetCount();
             const prefix = wpd.gettext("dataset") + " ";
             let i = 0;
+            let firstNewDataset = null;
             while (i < dsCount) {
                 let dsName = prefix + idx;
                 if (!datasetWithNameExists(dsName)) {
                     let ds = new wpd.Dataset();
                     ds.name = dsName;
+                    if (firstNewDataset == null) {
+                        firstNewDataset = ds;
+                    }
                     plotData.addDataset(ds);
                     const defaultAxes = getDefaultAxes();
                     if (defaultAxes != null) {
@@ -168,7 +172,10 @@ wpd.dataSeriesManagement = (function() {
                 }
                 idx++;
             }
-            wpd.tree.refreshPreservingSelection();
+            wpd.tree.refresh();
+            if (firstNewDataset != null) {
+                wpd.tree.selectPath("/" + wpd.gettext("datasets") + "/" + firstNewDataset.name);
+            }
         } else {
             wpd.messagePopup(wpd.gettext("add-dataset-error"),
                 wpd.gettext("add-dataset-count-error"),

--- a/javascript/controllers/datasetManagement.js
+++ b/javascript/controllers/datasetManagement.js
@@ -127,7 +127,8 @@ wpd.dataSeriesManagement = (function() {
         if (wpd.appData.isMultipage()) {
             wpd.appData.getPageManager().addDatasetsToCurrentPage([ds]);
         }
-        wpd.tree.refreshPreservingSelection();
+        wpd.tree.refresh();
+        wpd.tree.selectPath("/" + wpd.gettext("datasets") + "/" + ds.name);
         // dispatch dataset add event
         wpd.events.dispatch("wpd.dataset.add", {
             dataset: ds


### PR DESCRIPTION
Automatically selects the newly created dataset once a user adds a new dataset. If the user adds multiple datasets, the first of the newly added datasets is automatically selected.

### Motivation
I often found myself accidentally adding new data points to the previously active dataset rather than the newly created one. Automatically switching the selection to the new dataset matches user expectation and makes the workflow more ergonomic.

### Technical Changes
In `datasetManagement.js`:
* Replaced `wpd.tree.refreshPreservingSelection()` in `addSingleDataset()` with a call to `wpd.tree.refresh()` and `wpd.tree.selectPath()` targeting the new dataset.
* Modified `addMultipleDatasets()` to track the first new dataset that gets created, and select its path after the tree is refreshed.

### Verification (Manual Testing)
I manually tested the behavior locally in the UI:
* Single Dataset: Verified that adding a single dataset closes the popup and automatically selects and activates the new dataset in the sidebar tree.
* Multiple Datasets: Verified that adding multiple datasets (e.g., 3 datasets) closes the popup and automatically selects the first of the newly created datasets.